### PR TITLE
Create AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,33 @@
+# AUTHORS
+
+This file lists the maintainer and contributors of the **SOUL_SENSE_EXAM** project.
+
+---
+
+## 🧑‍💻 Maintainer
+
+- **Nupur Madaan** (`nupurmadaan04`)  
+  Project Owner & Primary Maintainer
+
+---
+
+## 👥 Contributors
+
+The following people have contributed to this project through code, documentation, testing, or ideas:
+
+- **Aleena Harold Peter** (`aleenaharoldpeter`)
+- **Gooichand** (`Gooichand`)
+- **Neeru** (`neeru24`)
+- **Nitesh Badgujar** (`NiteshBadgujar`)
+- **SSIS Live** (`ssislive`)
+- **Jot** (`mnjot7`)
+- **Sandeep Rdy** (`Sandeeprdy1729`)
+- **Roboticol** (`Roboticol`)
+
+---
+
+## Notes
+
+- Contributors are listed alphabetically by first name.
+- This list is maintained manually.
+- If you have contributed and your name is missing, please open a pull request to add yourself.


### PR DESCRIPTION
This update adds an **AUTHORS.md** file to the repository to recognize everyone who has contributed to the **SOUL_SENSE_EXAM** project. It helps maintain transparency and gives credit to the people who shaped the project.

* Lists the **maintainer**: Nupur Madaan (`nupurmadaan04`)
* Includes **contributors** who helped with code, documentation, testing, or ideas
* Contributors are listed alphabetically by first name
* The list is maintained manually, and anyone missing can add themselves via a pull request

This makes it easier for future contributors and collaborators to see who has worked on the project.
fixes #49
@nupurmadaan04 