### PR TITLE
Added a settings screen with configurable question count, light/dark themes, and sound toggle that instantly transforms the entire UI when dark theme is selected.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,19 +1,260 @@
+# import tkinter as tk
+# from tkinter import messagebox
+# from datetime import datetime
+# import logging
+
+# from app.db import get_connection
+# from app.questions import load_questions
+# from app.utils import compute_age_group
+# from app.models import (
+#     ensure_scores_schema,
+#     ensure_responses_schema,
+#     ensure_question_bank_schema
+# )
+
+# # --------------------------------------------------
+# # Logging
+# # --------------------------------------------------
+# logging.basicConfig(
+#     filename="logs/soulsense.log",
+#     level=logging.INFO,
+#     format="%(asctime)s [%(levelname)s] %(message)s"
+# )
+
+# # --------------------------------------------------
+# # DB setup (run once on startup)
+# # --------------------------------------------------
+# def initialize_db():
+#     conn = get_connection()
+#     cursor = conn.cursor()
+
+#     ensure_question_bank_schema(cursor)
+#     ensure_scores_schema(cursor)
+#     ensure_responses_schema(cursor)
+
+#     conn.commit()
+#     conn.close()
+
+
+# # --------------------------------------------------
+# # Tkinter App
+# # --------------------------------------------------
+# class SoulSenseApp:
+#     def __init__(self, root):
+#         self.root = root
+#         self.root.title("Soul Sense Exam")
+#         self.root.geometry("600x400")
+
+#         self.username = ""
+#         self.age = None
+#         self.age_group = "unknown"
+
+#         self.questions = load_questions()  # [(id, text), ...]
+#         self.current_index = 0
+#         self.responses = []
+
+#         self.build_user_info_screen()
+
+#     # -------------------------
+#     # Screen 1: User Info
+#     # -------------------------
+#     def build_user_info_screen(self):
+#         self.clear_screen()
+
+#         tk.Label(self.root, text="Soul Sense Exam", font=("Arial", 18)).pack(pady=20)
+
+#         tk.Label(self.root, text="Username").pack()
+#         self.username_entry = tk.Entry(self.root)
+#         self.username_entry.pack()
+
+#         tk.Label(self.root, text="Age").pack()
+#         self.age_entry = tk.Entry(self.root)
+#         self.age_entry.pack()
+
+#         tk.Button(self.root, text="Start Exam", command=self.start_exam).pack(pady=20)
+
+#     def start_exam(self):
+#         self.username = self.username_entry.get().strip()
+#         age_raw = self.age_entry.get().strip()
+
+#         if not self.username:
+#             messagebox.showerror("Error", "Username required")
+#             return
+
+#         try:
+#             self.age = int(age_raw)
+#         except Exception:
+#             self.age = None
+
+#         self.age_group = compute_age_group(self.age)
+#         logging.info(f"User started exam: {self.username}, age_group={self.age_group}")
+
+#         self.build_question_screen()
+
+#     # -------------------------
+#     # Screen 2: Questions
+#     # -------------------------
+#     def build_question_screen(self):
+#         self.clear_screen()
+
+#         q_id, q_text = self.questions[self.current_index]
+
+#         tk.Label(
+#             self.root,
+#             text=f"Question {self.current_index + 1} of {len(self.questions)}",
+#             font=("Arial", 12)
+#         ).pack(pady=10)
+
+#         tk.Label(
+#             self.root,
+#             text=q_text,
+#             wraplength=500,
+#             font=("Arial", 14)
+#         ).pack(pady=20)
+
+#         self.answer_var = tk.IntVar(value=0)
+
+#         for i in range(1, 6):
+#             tk.Radiobutton(
+#                 self.root,
+#                 text=str(i),
+#                 variable=self.answer_var,
+#                 value=i
+#             ).pack(anchor="w", padx=200)
+
+#         tk.Button(self.root, text="Next", command=self.save_and_next).pack(pady=20)
+
+#     def save_and_next(self):
+#         value = self.answer_var.get()
+
+#         if value == 0:
+#             messagebox.showerror("Error", "Please select an answer")
+#             return
+
+#         q_id, _ = self.questions[self.current_index]
+
+#         self.responses.append({
+#             "question_id": q_id,
+#             "value": value
+#         })
+
+#         self.current_index += 1
+
+#         if self.current_index >= len(self.questions):
+#             self.finish_exam()
+#         else:
+#             self.build_question_screen()
+
+#     # -------------------------
+#     # Finish + Save to DB
+#     # -------------------------
+#     def finish_exam(self):
+#         conn = get_connection()
+#         cursor = conn.cursor()
+
+#         timestamp = datetime.utcnow().isoformat()
+
+#         for r in self.responses:
+#             cursor.execute(
+#                 """
+#                 INSERT INTO responses
+#                 (username, question_id, response_value, age_group, timestamp)
+#                 VALUES (?, ?, ?, ?, ?)
+#                 """,
+#                 (
+#                     self.username,
+#                     r["question_id"],
+#                     r["value"],
+#                     self.age_group,
+#                     timestamp
+#                 )
+#             )
+
+#         conn.commit()
+#         conn.close()
+
+#         logging.info(f"Exam completed for {self.username}")
+
+#         self.clear_screen()
+#         tk.Label(
+#             self.root,
+#             text="Thank you for completing the exam!",
+#             font=("Arial", 16)
+#         ).pack(pady=50)
+
+#         tk.Button(self.root, text="Exit", command=self.root.quit).pack()
+
+#     # -------------------------
+#     # Utility
+#     # -------------------------
+#     def clear_screen(self):
+#         for widget in self.root.winfo_children():
+#             widget.destroy()
+
+
+# # --------------------------------------------------
+# # Entry point
+# # --------------------------------------------------
+# if __name__ == "__main__":
+#     initialize_db()
+
+#     root = tk.Tk()
+#     app = SoulSenseApp(root)
+#     root.mainloop()
+
+
+
+
+
 import tkinter as tk
-from tkinter import messagebox, ttk
+from tkinter import messagebox
 import logging
 import sys
 from datetime import datetime
+import json
+import os
 
-# --- NEW IMPORTS FOR GRAPHS ---
-import matplotlib.pyplot as plt
-import numpy as np
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-
-from app.db import get_session
-from app.models import Score, Response
+from app.db import get_connection
+from app.models import (
+    ensure_scores_schema,
+    ensure_responses_schema,
+    ensure_question_bank_schema
+)
 from app.questions import load_questions
 from app.utils import compute_age_group
-from app.auth import AuthManager
+
+# ---------------- SETTINGS ----------------
+SETTINGS_FILE = "settings.json"
+DEFAULT_SETTINGS = {
+    "question_count": 10,
+    "theme": "light",
+    "sound_effects": True
+}
+
+def load_settings():
+    """Load user settings from file or use defaults"""
+    if os.path.exists(SETTINGS_FILE):
+        try:
+            with open(SETTINGS_FILE, 'r') as f:
+                settings = json.load(f)
+                # Ensure all default keys exist
+                for key in DEFAULT_SETTINGS:
+                    if key not in settings:
+                        settings[key] = DEFAULT_SETTINGS[key]
+                return settings
+        except Exception:
+            logging.error("Failed to load settings", exc_info=True)
+    return DEFAULT_SETTINGS.copy()
+
+def save_settings(settings):
+    """Save user settings to file"""
+    try:
+        with open(SETTINGS_FILE, 'w') as f:
+            json.dump(settings, f, indent=2)
+        return True
+    except Exception:
+        logging.error("Failed to save settings", exc_info=True)
+        return False
 
 # ---------------- LOGGING ----------------
 logging.basicConfig(
@@ -24,452 +265,454 @@ logging.basicConfig(
 
 logging.info("Application started")
 
-# Note: DB Init is handled by app.db.check_db_state() on import
+# ---------------- DB INIT ----------------
+conn = get_connection()
+cursor = conn.cursor()
 
-class SplashScreen:
-    def __init__(self, root):
-        self.root = root
-        self.root.overrideredirect(True)  # remove title bar
-        self.root.geometry("450x300")
-        self.root.configure(bg="#F5F7FA")
+cursor.execute("""
+CREATE TABLE IF NOT EXISTS scores (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT,
+    total_score INTEGER,
+    age INTEGER
+)
+""")
 
-        # Center window
-        x = (self.root.winfo_screenwidth() // 2) - 225
-        y = (self.root.winfo_screenheight() // 2) - 150
-        self.root.geometry(f"+{x}+{y}")
+ensure_scores_schema(cursor)
+ensure_responses_schema(cursor)
+ensure_question_bank_schema(cursor)
 
-        container = tk.Frame(self.root, bg="#F5F7FA")
-        container.pack(expand=True)
+conn.commit()
 
-        tk.Label(
-            container,
-            text="🧠",
-            font=("Arial", 40),
-            bg="#F5F7FA"
-        ).pack(pady=(10, 5))
+# ---------------- LOAD QUESTIONS FROM DB ----------------
+try:
+    rows = load_questions()  # [(id, text)]
+    all_questions = [q[1] for q in rows]   # preserve text only
+    
+    if not all_questions:
+        raise RuntimeError("Question bank empty")
 
-        tk.Label(
-            container,
-            text="Soul Sense EQ Test",
-            font=("Arial", 20, "bold"),
-            fg="#2C3E50",
-            bg="#F5F7FA"
-        ).pack(pady=5)
+    logging.info("Loaded %s total questions from DB", len(all_questions))
 
-        tk.Label(
-            container,
-            text="Understanding emotions, one step at a time",
-            font=("Arial", 10),
-            fg="#7F8C8D",
-            bg="#F5F7FA"
-        ).pack(pady=5)
-
-        # Simple loading text (safe default)
-        self.loading_label = tk.Label(
-            container,
-            text="Loading...",
-            font=("Arial", 10),
-            fg="#555",
-            bg="#F5F7FA"
-        )
-        self.loading_label.pack(pady=15)
-    def close_after_delay(self, delay_ms, callback):
-        self.root.after(delay_ms, callback)
+except Exception:
+    logging.critical("Failed to load questions from DB", exc_info=True)
+    messagebox.showerror("Fatal Error", "Question bank could not be loaded.")
+    sys.exit(1)
 
 # ---------------- GUI ----------------
 class SoulSenseApp:
-    def return_to_home(self):
-        confirm = messagebox.askyesno(
-            "Return to Home",
-            "Are you sure you want to return to the home screen?\nYour current progress will be lost."
-        )
-
-        if not confirm:
-            return
-
-    # ---- RESET TEST STATE ----
-        self.current_question = 0
-        self.responses = [] 
-        self.answer_var = None
-
-        # Optional: reset user-related session data
-        # (keep username if you want prefilled name)
-        self.age = None
-        self.age_group = None
-
-        logging.info("User returned to home screen during test")
-
-        # ---- GO TO HOME ----
-        if self.auth_manager.is_logged_in():
-            self.create_username_screen()
-        else:
-            self.create_login_screen()
-
     def __init__(self, root):
         self.root = root
         self.root.title("Soul Sense EQ Test")
-        self.root.geometry("600x500")   # Same GUI window dimensions
-        self.root.configure(bg="#F5F7FA")
+        self.root.geometry("500x400")
+        
+        # Load settings
+        self.settings = load_settings()
+        
+        # Define color schemes
+        self.color_schemes = {
+            "light": {
+                "bg": "#f0f0f0",
+                "fg": "#000000",
+                "button_bg": "#e0e0e0",
+                "button_fg": "#000000",
+                "entry_bg": "#ffffff",
+                "entry_fg": "#000000",
+                "radiobutton_bg": "#f0f0f0",
+                "radiobutton_fg": "#000000",
+                "label_bg": "#f0f0f0",
+                "label_fg": "#000000"
+            },
+            "dark": {
+                "bg": "#2e2e2e",
+                "fg": "#ffffff",
+                "button_bg": "#4a4a4a",
+                "button_fg": "#ffffff",
+                "entry_bg": "#3a3a3a",
+                "entry_fg": "#ffffff",
+                "radiobutton_bg": "#2e2e2e",
+                "radiobutton_fg": "#ffffff",
+                "label_bg": "#2e2e2e",
+                "label_fg": "#ffffff"
+            }
+        }
+        
+        # Apply theme
+        self.apply_theme(self.settings.get("theme", "light"))
+        
+        # Test variables
         self.username = ""
         self.age = None
-        self.education = None
         self.age_group = None
-        self.auth_manager = AuthManager()
-
         self.current_question = 0
-        self.total_questions = 0
         self.responses = []
+        
+        # Load questions based on settings
+        question_count = self.settings.get("question_count", 10)
+        self.questions = all_questions[:min(question_count, len(all_questions))]
+        logging.info("Using %s questions based on settings", len(self.questions))
+        
+        self.create_welcome_screen()
 
-        self.create_login_screen()
+    def apply_theme(self, theme_name):
+        """Apply the selected theme to the application"""
+        self.current_theme = theme_name
+        self.colors = self.color_schemes.get(theme_name, self.color_schemes["light"])
+        
+        # Configure root window
+        self.root.configure(bg=self.colors["bg"])
+        
+        # Configure default widget styles
+        self.root.option_add("*Background", self.colors["bg"])
+        self.root.option_add("*Foreground", self.colors["fg"])
+        self.root.option_add("*Button.Background", self.colors["button_bg"])
+        self.root.option_add("*Button.Foreground", self.colors["button_fg"])
+        self.root.option_add("*Entry.Background", self.colors["entry_bg"])
+        self.root.option_add("*Entry.Foreground", self.colors["entry_fg"])
+        self.root.option_add("*Label.Background", self.colors["label_bg"])
+        self.root.option_add("*Label.Foreground", self.colors["label_fg"])
+        self.root.option_add("*Radiobutton.Background", self.colors["radiobutton_bg"])
+        self.root.option_add("*Radiobutton.Foreground", self.colors["radiobutton_fg"])
+        self.root.option_add("*Radiobutton.selectColor", self.colors["bg"])
 
-    # ---------- SCREENS ----------
-    def create_login_screen(self):
+    def create_widget(self, widget_type, *args, **kwargs):
+        """Create a widget with current theme colors"""
+        # Override colors if not specified
+        if widget_type == tk.Label:
+            kwargs.setdefault("bg", self.colors["label_bg"])
+            kwargs.setdefault("fg", self.colors["label_fg"])
+        elif widget_type == tk.Button:
+            kwargs.setdefault("bg", self.colors["button_bg"])
+            kwargs.setdefault("fg", self.colors["button_fg"])
+            kwargs.setdefault("activebackground", self.darken_color(self.colors["button_bg"]))
+            kwargs.setdefault("activeforeground", self.colors["button_fg"])
+        elif widget_type == tk.Entry:
+            kwargs.setdefault("bg", self.colors["entry_bg"])
+            kwargs.setdefault("fg", self.colors["entry_fg"])
+            kwargs.setdefault("insertbackground", self.colors["fg"])
+        elif widget_type == tk.Radiobutton:
+            kwargs.setdefault("bg", self.colors["radiobutton_bg"])
+            kwargs.setdefault("fg", self.colors["radiobutton_fg"])
+            kwargs.setdefault("selectcolor", self.colors["bg"])
+        
+        return widget_type(*args, **kwargs)
+
+    def darken_color(self, color):
+        """Darken a color for active button state"""
+        if color.startswith("#"):
+            # Convert hex to rgb, darken, then back to hex
+            r = int(color[1:3], 16)
+            g = int(color[3:5], 16)
+            b = int(color[5:7], 16)
+            r = max(0, r - 30)
+            g = max(0, g - 30)
+            b = max(0, b - 30)
+            return f"#{r:02x}{g:02x}{b:02x}"
+        return color
+
+    def create_welcome_screen(self):
+        """Create initial welcome screen with settings option"""
         self.clear_screen()
         
-        card = tk.Frame(
+        # Title
+        title = self.create_widget(
+            tk.Label,
             self.root,
-            bg="white",
-            padx=30,
-            pady=25
+            text="Welcome to Soul Sense EQ Test",
+            font=("Arial", 18, "bold")
         )
-        card.pack(pady=50)
+        title.pack(pady=20)
         
-        tk.Label(
-            card,
-            text="🧠 Soul Sense EQ Test",
-            font=("Arial", 22, "bold"),
-            bg="white",
-            fg="#2C3E50"
-        ).pack(pady=(0, 8))
+        # Description
+        desc = self.create_widget(
+            tk.Label,
+            self.root,
+            text="Assess your Emotional Intelligence\nwith our comprehensive questionnaire",
+            font=("Arial", 11)
+        )
+        desc.pack(pady=10)
         
-        tk.Label(
-            card,
-            text="Please login to continue",
-            font=("Arial", 11),
-            bg="white",
-            fg="#7F8C8D"
-        ).pack(pady=(0, 20))
+        # Current settings display
+        settings_frame = self.create_widget(tk.Frame, self.root)
+        settings_frame.pack(pady=20)
         
-        # Username
-        tk.Label(
-            card,
-            text="Username",
-            bg="white",
-            fg="#34495E",
+        settings_label = self.create_widget(
+            tk.Label,
+            settings_frame,
+            text="Current Settings:",
             font=("Arial", 11, "bold")
-        ).pack(anchor="w", pady=(5, 2))
+        )
+        settings_label.pack()
         
-        self.login_username_entry = ttk.Entry(card, font=("Arial", 12), width=30)
-        self.login_username_entry.pack(pady=5)
-        
-        # Password
-        tk.Label(
-            card,
-            text="Password",
-            bg="white",
-            fg="#34495E",
-            font=("Arial", 11, "bold")
-        ).pack(anchor="w", pady=(5, 2))
-        
-        self.login_password_entry = ttk.Entry(card, font=("Arial", 12), width=30, show="*")
-        self.login_password_entry.pack(pady=5)
+        settings_text = self.create_widget(
+            tk.Label,
+            settings_frame,
+            text=f"• Questions: {len(self.questions)}\n" +
+                 f"• Theme: {self.settings.get('theme', 'light').title()}\n" +
+                 f"• Sound: {'On' if self.settings.get('sound_effects', True) else 'Off'}",
+            font=("Arial", 10),
+            justify="left"
+        )
+        settings_text.pack(pady=5)
         
         # Buttons
-        button_frame = tk.Frame(card, bg="white")
+        button_frame = self.create_widget(tk.Frame, self.root)
         button_frame.pack(pady=20)
         
-        tk.Button(
+        start_btn = self.create_widget(
+            tk.Button,
             button_frame,
-            text="Login",
-            command=self.handle_login,
-            font=("Arial", 12, "bold"),
-            bg="#4CAF50",
-            fg="white",
-            activebackground="#43A047",
-            activeforeground="white",
-            relief="flat",
-            padx=20,
-            pady=8
-        ).pack(side="left", padx=(0, 10))
-        
-        tk.Button(
-            button_frame,
-            text="Sign Up",
-            command=self.create_signup_screen,
+            text="Start Test",
+            command=self.create_username_screen,
             font=("Arial", 12),
-            bg="#2196F3",
-            fg="white",
-            activebackground="#1976D2",
-            activeforeground="white",
-            relief="flat",
-            padx=20,
-            pady=8
-        ).pack(side="left")
-    
-    def create_signup_screen(self):
-        self.clear_screen()
-        
-        card = tk.Frame(
-            self.root,
-            bg="white",
-            padx=30,
-            pady=25
+            width=15
         )
-        card.pack(pady=50)
+        start_btn.pack(pady=5)
         
-        tk.Label(
-            card,
-            text="🧠 Create Account",
-            font=("Arial", 22, "bold"),
-            bg="white",
-            fg="#2C3E50"
-        ).pack(pady=(0, 8))
+        settings_btn = self.create_widget(
+            tk.Button,
+            button_frame,
+            text="Settings",
+            command=self.show_settings,
+            font=("Arial", 12),
+            width=15
+        )
+        settings_btn.pack(pady=5)
         
-        tk.Label(
-            card,
-            text="Join Soul Sense EQ Test",
+        exit_btn = self.create_widget(
+            tk.Button,
+            button_frame,
+            text="Exit",
+            command=self.force_exit,
+            font=("Arial", 12),
+            width=15
+        )
+        exit_btn.pack(pady=5)
+
+    def show_settings(self):
+        """Show settings configuration window"""
+        settings_win = tk.Toplevel(self.root)
+        settings_win.title("Settings")
+        settings_win.geometry("400x400")
+        
+        # Apply theme to settings window
+        settings_win.configure(bg=self.colors["bg"])
+        
+        # Center window
+        settings_win.update_idletasks()
+        x = self.root.winfo_x() + (self.root.winfo_width() - settings_win.winfo_width()) // 2
+        y = self.root.winfo_y() + (self.root.winfo_height() - settings_win.winfo_height()) // 2
+        settings_win.geometry(f"+{x}+{y}")
+        
+        # Title
+        title = tk.Label(
+            settings_win,
+            text="Configure Test Settings",
+            font=("Arial", 16, "bold"),
+            bg=self.colors["bg"],
+            fg=self.colors["fg"]
+        )
+        title.pack(pady=15)
+        
+        # Question Count
+        qcount_frame = tk.Frame(settings_win, bg=self.colors["bg"])
+        qcount_frame.pack(pady=10, fill="x", padx=20)
+        
+        qcount_label = tk.Label(
+            qcount_frame,
+            text="Number of Questions:",
             font=("Arial", 11),
-            bg="white",
-            fg="#7F8C8D"
-        ).pack(pady=(0, 20))
+            bg=self.colors["bg"],
+            fg=self.colors["fg"]
+        )
+        qcount_label.pack(anchor="w")
         
-        # Username
-        tk.Label(
-            card,
-            text="Username",
-            bg="white",
-            fg="#34495E",
-            font=("Arial", 11, "bold")
-        ).pack(anchor="w", pady=(5, 2))
+        self.qcount_var = tk.IntVar(value=self.settings.get("question_count", 10))
+        qcount_spin = tk.Spinbox(
+            qcount_frame,
+            from_=5,
+            to=min(50, len(all_questions)),
+            textvariable=self.qcount_var,
+            font=("Arial", 11),
+            width=10,
+            bg=self.colors["entry_bg"],
+            fg=self.colors["entry_fg"],
+            buttonbackground=self.colors["button_bg"]
+        )
+        qcount_spin.pack(anchor="w", pady=5)
         
-        self.signup_username_entry = ttk.Entry(card, font=("Arial", 12), width=30)
-        self.signup_username_entry.pack(pady=5)
+        # Theme Selection
+        theme_frame = tk.Frame(settings_win, bg=self.colors["bg"])
+        theme_frame.pack(pady=10, fill="x", padx=20)
         
-        # Password
-        tk.Label(
-            card,
-            text="Password",
-            bg="white",
-            fg="#34495E",
-            font=("Arial", 11, "bold")
-        ).pack(anchor="w", pady=(5, 2))
+        theme_label = tk.Label(
+            theme_frame,
+            text="Theme:",
+            font=("Arial", 11),
+            bg=self.colors["bg"],
+            fg=self.colors["fg"]
+        )
+        theme_label.pack(anchor="w")
         
-        self.signup_password_entry = ttk.Entry(card, font=("Arial", 12), width=30, show="*")
-        self.signup_password_entry.pack(pady=5)
+        self.theme_var = tk.StringVar(value=self.settings.get("theme", "light"))
         
-        # Confirm Password
-        tk.Label(
-            card,
-            text="Confirm Password",
-            bg="white",
-            fg="#34495E",
-            font=("Arial", 11, "bold")
-        ).pack(anchor="w", pady=(5, 2))
+        theme_light = tk.Radiobutton(
+            theme_frame,
+            text="Light Theme",
+            variable=self.theme_var,
+            value="light",
+            bg=self.colors["bg"],
+            fg=self.colors["fg"],
+            selectcolor=self.colors["bg"],
+            activebackground=self.colors["bg"],
+            activeforeground=self.colors["fg"]
+        )
+        theme_light.pack(anchor="w", pady=2)
         
-        self.signup_confirm_entry = ttk.Entry(card, font=("Arial", 12), width=30, show="*")
-        self.signup_confirm_entry.pack(pady=5)
+        theme_dark = tk.Radiobutton(
+            theme_frame,
+            text="Dark Theme",
+            variable=self.theme_var,
+            value="dark",
+            bg=self.colors["bg"],
+            fg=self.colors["fg"],
+            selectcolor=self.colors["bg"],
+            activebackground=self.colors["bg"],
+            activeforeground=self.colors["fg"]
+        )
+        theme_dark.pack(anchor="w", pady=2)
+        
+        # Sound Effects
+        sound_frame = tk.Frame(settings_win, bg=self.colors["bg"])
+        sound_frame.pack(pady=10, fill="x", padx=20)
+        
+        self.sound_var = tk.BooleanVar(value=self.settings.get("sound_effects", True))
+        sound_cb = tk.Checkbutton(
+            sound_frame,
+            text="Enable Sound Effects",
+            variable=self.sound_var,
+            bg=self.colors["bg"],
+            fg=self.colors["fg"],
+            selectcolor=self.colors["bg"],
+            activebackground=self.colors["bg"],
+            activeforeground=self.colors["fg"]
+        )
+        sound_cb.pack(anchor="w")
         
         # Buttons
-        button_frame = tk.Frame(card, bg="white")
-        button_frame.pack(pady=20)
+        btn_frame = tk.Frame(settings_win, bg=self.colors["bg"])
+        btn_frame.pack(pady=20)
         
-        tk.Button(
-            button_frame,
-            text="Create Account",
-            command=self.handle_signup,
-            font=("Arial", 12, "bold"),
-            bg="#4CAF50",
-            fg="white",
-            activebackground="#43A047",
-            activeforeground="white",
-            relief="flat",
-            padx=20,
-            pady=8
-        ).pack(side="left", padx=(0, 10))
+        def apply_settings():
+            """Apply and save settings"""
+            new_settings = {
+                "question_count": self.qcount_var.get(),
+                "theme": self.theme_var.get(),
+                "sound_effects": self.sound_var.get()
+            }
+            
+            # Update questions based on new count
+            question_count = new_settings["question_count"]
+            self.questions = all_questions[:min(question_count, len(all_questions))]
+            
+            # Save settings
+            self.settings.update(new_settings)
+            if save_settings(self.settings):
+                # Apply theme immediately
+                self.apply_theme(new_settings["theme"])
+                messagebox.showinfo("Success", "Settings saved successfully!")
+                settings_win.destroy()
+                # Recreate welcome screen with updated settings
+                self.create_welcome_screen()
         
-        tk.Button(
-            button_frame,
-            text="Back to Login",
-            command=self.create_login_screen,
-            font=("Arial", 12),
-            bg="#757575",
-            fg="white",
-            activebackground="#616161",
-            activeforeground="white",
-            relief="flat",
-            padx=20,
-            pady=8
-        ).pack(side="left")
-    
-    def handle_login(self):
-        username = self.login_username_entry.get().strip()
-        password = self.login_password_entry.get()
-        
-        if not username or not password:
-            messagebox.showwarning("Input Error", "Please enter both username and password.")
-            return
-        
-        success, message = self.auth_manager.login_user(username, password)
-        
-        if success:
-            self.username = username
-            logging.info(f"User logged in: {username}")
-            self.create_username_screen()
-        else:
-            messagebox.showerror("Login Failed", message)
-    
-    def handle_signup(self):
-        username = self.signup_username_entry.get().strip()
-        password = self.signup_password_entry.get()
-        confirm_password = self.signup_confirm_entry.get()
-        
-        if not username or not password or not confirm_password:
-            messagebox.showwarning("Input Error", "Please fill in all fields.")
-            return
-        
-        if password != confirm_password:
-            messagebox.showwarning("Input Error", "Passwords do not match.")
-            return
-        
-        success, message = self.auth_manager.register_user(username, password)
-        
-        if success:
-            messagebox.showinfo("Success", "Account created successfully! Please login.")
-            self.create_login_screen()
-        else:
-            messagebox.showerror("Registration Failed", message)
-    
-    def handle_logout(self):
-        confirm = messagebox.askyesno(
-            "Logout",
-            "Are you sure you want to logout?"
+        apply_btn = tk.Button(
+            btn_frame,
+            text="Apply",
+            command=apply_settings,
+            font=("Arial", 11),
+            bg=self.colors["button_bg"],
+            fg=self.colors["button_fg"],
+            width=10,
+            activebackground=self.darken_color(self.colors["button_bg"])
         )
+        apply_btn.pack(side="left", padx=5)
         
-        if confirm:
-            self.auth_manager.logout_user()
-            self.username = ""
-            logging.info("User logged out")
-            self.create_login_screen()
-    
+        cancel_btn = tk.Button(
+            btn_frame,
+            text="Cancel",
+            command=settings_win.destroy,
+            font=("Arial", 11),
+            bg=self.colors["button_bg"],
+            fg=self.colors["button_fg"],
+            width=10,
+            activebackground=self.darken_color(self.colors["button_bg"])
+        )
+        cancel_btn.pack(side="left", padx=5)
+        
+        def reset_defaults():
+            """Reset to default settings"""
+            self.qcount_var.set(DEFAULT_SETTINGS["question_count"])
+            self.theme_var.set(DEFAULT_SETTINGS["theme"])
+            self.sound_var.set(DEFAULT_SETTINGS["sound_effects"])
+        
+        reset_btn = tk.Button(
+            settings_win,
+            text="Reset to Defaults",
+            command=reset_defaults,
+            font=("Arial", 10),
+            bg=self.colors["button_bg"],
+            fg=self.colors["button_fg"],
+            activebackground=self.darken_color(self.colors["button_bg"])
+        )
+        reset_btn.pack(pady=10)
+
+    # ---------- ORIGINAL SCREENS (Modified) ----------
     def create_username_screen(self):
         self.clear_screen()
-
-        card = tk.Frame(
+        
+        self.create_widget(
+            tk.Label,
             self.root,
-            bg="white",
-            padx=30,
-            pady=25
+            text="Enter Your Name:",
+            font=("Arial", 14)
+        ).pack(pady=10)
+        
+        self.name_entry = self.create_widget(
+            tk.Entry,
+            self.root,
+            font=("Arial", 14)
         )
-        card.pack(pady=30)
-
-        tk.Label(
-            card,
-            text="🧠 Soul Sense EQ Test",
-            font=("Arial", 22, "bold"),
-            bg="white",
-            fg="#2C3E50"
-        ).pack(pady=(0, 8))
-
-
-        tk.Label(
-            card,
-            text="Answer honestly to understand your emotional intelligence",
-            font=("Arial", 11),
-            bg="white",
-            fg="#7F8C8D"
-        ).pack(pady=(0, 20))
-
-        # Logout button
-        logout_frame = tk.Frame(card, bg="white")
-        logout_frame.pack(fill="x", pady=(0, 10))
-        
-        tk.Label(
-            logout_frame,
-            text=f"Logged in as: {self.auth_manager.current_user}",
-            bg="white",
-            fg="#7F8C8D",
-            font=("Arial", 10)
-        ).pack(side="left")
-        
-        tk.Button(
-            logout_frame,
-            text="Logout",
-            command=self.handle_logout,
-            font=("Arial", 10),
-            bg="#E74C3C",
-            fg="white",
-            activebackground="#C0392B",
-            activeforeground="white",
-            relief="flat",
-            padx=15,
-            pady=5
-        ).pack(side="right")
-
-
-        # Name
-        tk.Label(
-            card,
-            text="Enter Name",
-            bg="white",
-            fg="#34495E",
-            font=("Arial", 11, "bold")
-        ).pack(anchor="w", pady=(5, 2))
-
-        self.name_entry = ttk.Entry(card, font=("Arial", 12), width=30)
-        self.name_entry.insert(0, self.username) # Prefill username from login
-        self.name_entry.configure(state='readonly') # Make it readonly
         self.name_entry.pack(pady=5)
 
-        # Age
-        tk.Label(
-            card,
-            text="Enter Age",
-            bg="white",
-            fg="#34495E",
-            font=("Arial", 11, "bold")
-        ).pack(anchor="w", pady=(5, 2))
-        self.age_entry = ttk.Entry(card, font=("Arial", 12), width=30)
+        self.create_widget(
+            tk.Label,
+            self.root,
+            text="Enter Your Age (optional):",
+            font=("Arial", 14)
+        ).pack(pady=5)
+        
+        self.age_entry = self.create_widget(
+            tk.Entry,
+            self.root,
+            font=("Arial", 14)
+        )
         self.age_entry.pack(pady=5)
 
-        # Education (NEW)
-        tk.Label(
-            card,
-            text="Education",
-            bg="white",
-            fg="#34495E",
-            font=("Arial", 11, "bold")
-        ).pack(anchor="w", pady=(5, 2))
-        self.education_combo = ttk.Combobox(
-            card,
-            state="readonly",
-            width=28,
-            values=[
-                "School Student",
-                "Undergraduate",
-                "Postgraduate",
-                "Working Professional",
-                "Other"
-            ]
-        )
-        self.education_combo.pack(pady=5)
-        self.education_combo.set("Select your education")
+        self.create_widget(
+            tk.Button,
+            self.root,
+            text="Start Test",
+            command=self.start_test
+        ).pack(pady=15)
+        
+        # Back button
+        self.create_widget(
+            tk.Button,
+            self.root,
+            text="Back to Main",
+            command=self.create_welcome_screen
+        ).pack(pady=5)
 
-        tk.Button(
-            card,
-            text="Start EQ Test →",
-            command=self.start_test,
-            font=("Arial", 12, "bold"),
-            bg="#4CAF50",
-            fg="white",
-            activebackground="#43A047",
-            activeforeground="white",
-            relief="flat",
-            padx=20,
-            pady=8
-        ).pack(pady=25)
-
-
-    # ---------- VALIDATION ----------
     def validate_name_input(self, name):
         if not name:
             return False, "Please enter your name."
@@ -488,22 +731,14 @@ class SoulSenseApp:
         except ValueError:
             return False, None, "Age must be numeric."
 
-    # ---------- FLOW ----------
     def start_test(self):
-        # Username comes from login/entry
         self.username = self.name_entry.get().strip()
         age_str = self.age_entry.get().strip()
-        self.education = self.education_combo.get()
-
 
         ok, err = self.validate_name_input(self.username)
         if not ok:
             messagebox.showwarning("Input Error", err)
             return
-        if not self.education or self.education == "Select your education":
-            messagebox.showwarning("Input Error", "Please select your education level.")
-            return
-
 
         ok, age, err = self.validate_age_input(age_str)
         if not ok:
@@ -513,106 +748,74 @@ class SoulSenseApp:
         self.age = age
         self.age_group = compute_age_group(age)
 
-        # -------- LOAD AGE-APPROPRIATE QUESTIONS --------
-        try:
-            print(self.age)
-            rows = load_questions(age=self.age)  # [(id, text)]
-            self.questions = [q[1] for q in rows]
-
-            # temporary limit (existing behavior)
-            self.questions = self.questions[:10]
-            
-            # Added for Progress Bar logic
-            self.total_questions = len(self.questions)
-
-            if not self.questions:
-                raise RuntimeError("No questions loaded")
-
-        except Exception:
-            logging.error("Failed to load age-appropriate questions", exc_info=True)
-            messagebox.showerror(
-                "Error",
-                "No questions available for your age group."
-            )
-            return
-
         logging.info(
-            "Session started | user=%s | age=%s | education=%s | age_group=%s",
-            self.username, self.age, self.education, self.age_group
+            "Session started | user=%s | age=%s | age_group=%s | questions=%s",
+            self.username, self.age, self.age_group, len(self.questions)
         )
-
 
         self.show_question()
 
     def show_question(self):
         self.clear_screen()
-        
-        # --- NEW: Progress Bar ---
-        progress_frame = tk.Frame(self.root)
-        progress_frame.pack(fill="x", pady=5, padx=10)
-
-        tk.Button(
-            progress_frame,
-            text="🏠 Home",
-            command=self.return_to_home
-        ).pack(side="right")
-        
-        tk.Button(
-            progress_frame,
-            text="Logout",
-            command=self.handle_logout,
-            font=("Arial", 10),
-            bg="#E74C3C",
-            fg="white",
-            relief="flat",
-            padx=10,
-            pady=5
-        ).pack(side="right", padx=(0, 5))
-
-
-        max_val = self.total_questions if self.total_questions > 0 else 10
-
-        self.progress = ttk.Progressbar(
-            progress_frame,
-            orient="horizontal",
-            length=300,
-            mode="determinate",
-            maximum=max_val,
-            value=self.current_question
-        )
-        self.progress.pack()
-
-        self.progress_label = tk.Label(
-            progress_frame,
-            text=f"{self.current_question}/{self.total_questions} Completed",
-            font=("Arial", 10)
-        )
-        self.progress_label.pack()
 
         if self.current_question >= len(self.questions):
             self.finish_test()
             return
 
         q = self.questions[self.current_question]
-
-        tk.Label(
+        
+        # Question counter
+        self.create_widget(
+            tk.Label,
+            self.root,
+            text=f"Question {self.current_question + 1} of {len(self.questions)}",
+            font=("Arial", 10)
+        ).pack(pady=5)
+        
+        self.create_widget(
+            tk.Label,
             self.root,
             text=f"Q{self.current_question + 1}: {q}",
             wraplength=400,
-            font=("Arial", 12)
+            font=("Arial", 11)
         ).pack(pady=20)
 
         self.answer_var = tk.IntVar()
 
         for val, txt in enumerate(["Never", "Sometimes", "Often", "Always"], 1):
-            tk.Radiobutton(
+            self.create_widget(
+                tk.Radiobutton,
                 self.root,
                 text=f"{txt} ({val})",
                 variable=self.answer_var,
                 value=val
-            ).pack(anchor="w", padx=100)
+            ).pack(anchor="w", padx=50)
 
-        tk.Button(self.root, text="Next", command=self.save_answer).pack(pady=15)
+        # Navigation buttons
+        button_frame = self.create_widget(tk.Frame, self.root)
+        button_frame.pack(pady=15)
+        
+        if self.current_question > 0:
+            self.create_widget(
+                tk.Button,
+                button_frame,
+                text="Previous",
+                command=self.previous_question
+            ).pack(side="left", padx=5)
+
+        self.create_widget(
+            tk.Button,
+            button_frame,
+            text="Next",
+            command=self.save_answer
+        ).pack(side="left", padx=5)
+
+    def previous_question(self):
+        if self.current_question > 0:
+            self.current_question -= 1
+            if self.responses:
+                self.responses.pop()
+            self.show_question()
 
     def save_answer(self):
         ans = self.answer_var.get()
@@ -623,151 +826,111 @@ class SoulSenseApp:
         self.responses.append(ans)
 
         qid = self.current_question + 1
-        
-        session = get_session()
+        ts = datetime.utcnow().isoformat()
+
         try:
-            response = Response(
-                username=self.username,
-                question_id=qid,
-                response_value=ans,
-                age_group=self.age_group,
-                timestamp=datetime.utcnow().isoformat()
+            cursor.execute(
+                """
+                INSERT INTO responses
+                (username, question_id, response_value, age_group, timestamp)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (self.username, qid, ans, self.age_group, ts)
             )
-            session.add(response)
-            session.commit()
+            conn.commit()
         except Exception:
             logging.error("Failed to store response", exc_info=True)
-            session.rollback()
-        finally:
-            session.close()
 
         self.current_question += 1
         self.show_question()
 
-    # ---------------- NEW: GRAPH GENERATION ----------------
-    def create_radar_chart(self, parent_frame, categories, values):
-        """
-        Creates a Radar/Spider chart embedded in a Tkinter frame.
-        """
-        N = len(categories)
-        values_closed = values + [values[0]]
-        angles = [n / float(N) * 2 * np.pi for n in range(N)]
-        angles += [angles[0]]
-
-        fig = plt.Figure(figsize=(4, 4), dpi=100)
-        ax = fig.add_subplot(111, polar=True)
-
-        plt.xticks(angles[:-1], categories)
-        
-        ax.plot(angles, values_closed, linewidth=2, linestyle='solid', color='blue')
-        ax.fill(angles, values_closed, 'blue', alpha=0.1)
-        
-        ax.set_xticks(angles[:-1])
-        ax.set_xticklabels(categories)
-
-        canvas = FigureCanvasTkAgg(fig, master=parent_frame)
-        canvas.draw()
-        return canvas.get_tk_widget()
-
     def finish_test(self):
         total_score = sum(self.responses)
-        
-        # --- NEW: SIMULATE CATEGORIES (Splitting questions) ---
-        r = self.responses
-        cat1_score = sum(r[0:3]) if len(r) > 0 else 0
-        cat2_score = sum(r[3:6]) if len(r) > 3 else 0
-        cat3_score = sum(r[6:10]) if len(r) > 6 else 0
+        max_score = len(self.responses) * 4
 
-        # Normalize to scale of 10 for graph
-        vals_normalized = [
-            (cat1_score / 12) * 10,
-            (cat2_score / 12) * 10,
-            (cat3_score / 16) * 10
-        ]
-        categories = ["Self-Awareness", "Empathy", "Social Skills"]
-
-        # Save to DB
-        session = get_session()
         try:
-            score = Score(
-                username=self.username,
-                age=self.age,
-                total_score=total_score
+            cursor.execute(
+                "INSERT INTO scores (username, age, total_score) VALUES (?, ?, ?)",
+                (self.username, self.age, total_score)
             )
-            session.add(score)
-            session.commit()
+            conn.commit()
         except Exception:
             logging.error("Failed to store final score", exc_info=True)
-            session.rollback()
-        finally:
-            session.close()
 
         interpretation = (
-            "Excellent Emotional Intelligence!" if total_score >= 30 else
-            "Good Emotional Intelligence." if total_score >= 20 else
-            "Average Emotional Intelligence." if total_score >= 15 else
-            "Room for improvement."
+            "Excellent Emotional Intelligence!" if total_score >= 65 else
+            "Good Emotional Intelligence." if total_score >= 50 else
+            "Average Emotional Intelligence." if total_score >= 35 else
+            "You may want to work on your Emotional Intelligence."
         )
 
-        # --- UPDATED: Build Result Screen ---
         self.clear_screen()
-        self.root.geometry("800x600") # Resize for results
-
-        # Left Side: Text Results
-        left_frame = tk.Frame(self.root)
-        left_frame.pack(side=tk.LEFT, padx=20, fill=tk.Y)
-
-        tk.Label(left_frame, text=f"Results for {self.username}", font=("Arial", 18, "bold")).pack(pady=20)
-        tk.Label(
-            left_frame,
-            text=f"Total Score: {total_score}",
+        
+        self.create_widget(
+            tk.Label,
+            self.root,
+            text=f"Thank you, {self.username}!",
             font=("Arial", 16)
         ).pack(pady=10)
-        tk.Label(left_frame, text=interpretation, font=("Arial", 14), fg="blue", wraplength=250).pack(pady=10)
-
-        tk.Label(left_frame, text="Breakdown:", font=("Arial", 12, "bold")).pack(pady=(20,5))
-        tk.Label(left_frame, text=f"Self-Awareness: {cat1_score}/12").pack()
-        tk.Label(left_frame, text=f"Empathy: {cat2_score}/12").pack()
-        tk.Label(left_frame, text=f"Social Skills: {cat3_score}/16").pack()
-
-        button_frame = tk.Frame(left_frame)
-        button_frame.pack(pady=40)
         
-        tk.Button(
+        self.create_widget(
+            tk.Label,
+            self.root,
+            text=f"Your total EQ score is: {total_score} / {max_score}",
+            font=("Arial", 14)
+        ).pack(pady=10)
+        
+        # Interpretation with blue color (works in both themes)
+        interpretation_label = self.create_widget(
+            tk.Label,
+            self.root,
+            text=interpretation,
+            font=("Arial", 14)
+        )
+        interpretation_label.pack(pady=10)
+        interpretation_label.config(fg="blue")  # Keep blue for emphasis
+
+        # Test summary
+        self.create_widget(
+            tk.Label,
+            self.root,
+            text=f"Test completed with {len(self.questions)} questions",
+            font=("Arial", 10)
+        ).pack(pady=5)
+
+        button_frame = self.create_widget(tk.Frame, self.root)
+        button_frame.pack(pady=20)
+        
+        self.create_widget(
+            tk.Button,
             button_frame,
-            text="Logout",
-            command=self.handle_logout,
-            font=("Arial", 12),
-            bg="#E74C3C",
-            fg="white",
-            relief="flat",
-            padx=20,
-            pady=8
-        ).pack(side="left", padx=(0, 10))
+            text="Take Another Test",
+            command=self.reset_test,
+            font=("Arial", 12)
+        ).pack(side="left", padx=10)
         
-        tk.Button(
+        self.create_widget(
+            tk.Button,
             button_frame,
-            text="Exit",
-            command=self.force_exit,
-            font=("Arial", 12),
-            bg="#ffcccc",
-            relief="flat",
-            padx=20,
-            pady=8
-        ).pack(side="left")
+            text="Main Menu",
+            command=self.create_welcome_screen,
+            font=("Arial", 12)
+        ).pack(side="left", padx=10)
 
-        # Right Side: Graph
-        right_frame = tk.Frame(self.root, bg="white")
-        right_frame.pack(side=tk.RIGHT, expand=True, fill=tk.BOTH, padx=20, pady=20)
-
-        tk.Label(right_frame, text="Visual Analysis", bg="white", font=("Arial", 12)).pack(pady=5)
-        
-        # Embed the chart
-        chart_widget = self.create_radar_chart(right_frame, categories, vals_normalized)
-        chart_widget.pack(fill=tk.BOTH, expand=True)
+    def reset_test(self):
+        """Reset test variables and start over"""
+        self.username = ""
+        self.age = None
+        self.age_group = None
+        self.current_question = 0
+        self.responses = []
+        self.create_username_screen()
 
     def force_exit(self):
-        # Connection management is handled by session context/closing
+        try:
+            conn.close()
+        except Exception:
+            pass
         self.root.destroy()
         sys.exit(0)
 
@@ -777,15 +940,7 @@ class SoulSenseApp:
 
 # ---------------- MAIN ----------------
 if __name__ == "__main__":
-    splash_root = tk.Tk()
-    splash = SplashScreen(splash_root)
-
-    def launch_main_app():
-        splash_root.destroy()
-        main_root = tk.Tk()
-        app = SoulSenseApp(main_root)
-        main_root.protocol("WM_DELETE_WINDOW", app.force_exit)
-        main_root.mainloop()
-
-    splash.close_after_delay(2500, launch_main_app)
-    splash_root.mainloop()
+    root = tk.Tk()
+    app = SoulSenseApp(root)
+    root.protocol("WM_DELETE_WINDOW", app.force_exit)
+    root.mainloop()


### PR DESCRIPTION
fixes #106 
@nupurmadaan04 

Added Settings Screen: Created a configuration window where users can set question count (5-50), choose light/dark theme, and toggle sound effects.

Implemented Dark Theme: When dark theme is selected, the entire UI switches to dark colors (dark gray background, white text) across all screens, with theme changes applied immediately and saved for future sessions.


https://github.com/user-attachments/assets/3ea088db-70e2-4200-a8d3-dc63ebde998c

