### PR TITLE
Correct workflow (FIXED)

### DIFF
--- a/.github/workflows/update-authors.yml
+++ b/.github/workflows/update-authors.yml
@@ -15,10 +15,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # IMPORTANT for contributor history
 
       - name: Generate AUTHORS.md
         uses: akhilmhdh/contributors-readme-action@v2.3.6
         with:
-          file: AUTHORS.md
+          file: SOUL_SENSE_EXAM/docs/AUTHORS.md
           marker: CONTRIBUTORS-LIST
           commit_message: "chore: update AUTHORS.md contributors"


### PR DESCRIPTION
fixes #221

The workflow is running, but it’s not updating SOUL_SENSE_EXAM/docs/AUTHORS.md because the action defaults to the repo root so fixed it 
@nupurmadaan04 