### PR TITLE
Automatically reopen issues when a PR is reverted

### DIFF
--- a/.github/workflows/reopen-issues-on-revert.yml
+++ b/.github/workflows/reopen-issues-on-revert.yml
@@ -1,0 +1,73 @@
+name: Reopen issues on PR revert
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  pull-requests: read
+  issues: write
+  contents: read
+
+jobs:
+  reopen-issues:
+    runs-on: ubuntu-latest
+
+    # Run only if PR was merged AND looks like a revert PR
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'Revert')
+
+    steps:
+      - name: Reopen issues referenced in reverted PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Combine PR title + body
+            const text = `${pr.title}\n${pr.body || ""}`;
+
+            // Extract issue numbers like #12
+            const issueNumbers = [...text.matchAll(/#(\d+)/g)]
+              .map(match => match[1]);
+
+            if (issueNumbers.length === 0) {
+              console.log("No issues referenced in revert PR.");
+              return;
+            }
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
+
+                // Reopen only if currently closed
+                if (issue.data.state === "closed") {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    state: "open",
+                  });
+
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `🔄 This issue was automatically reopened because PR #${pr.number} reverted a previous change.`,
+                  });
+
+                  console.log(`Reopened issue #${issueNumber}`);
+                } else {
+                  console.log(`Issue #${issueNumber} already open.`);
+                }
+              } catch (error) {
+                console.log(
+                  `Failed to process issue #${issueNumber}: ${error.message}`
+                );
+              }
+            }


### PR DESCRIPTION

Automatically reopens issues when a merged pull request is reverted to keep issue status accurate.

## Features
- Detects **revert PRs** (merged PRs with `Revert` in the title)
- Identifies all referenced issues in the PR
- Reopens closed issues automatically
- Adds a comment explaining the reopen reason
- Powered by `github-actions[bot]`

Closes #233 
