### PR TITLE
Automatically assign PR to author on merge

### DIFF
--- a/.github/workflows/assign-pr-author-on-merge.yml
+++ b/.github/workflows/assign-pr-author-on-merge.yml
@@ -1,0 +1,33 @@
+name: Assign PR author on merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Assign PR to its author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Get the PR author's username
+            const author = pr.user.login;
+
+            // Assign PR to the author
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              assignees: [author],
+            });
+
+            console.log(`PR #${pr.number} assigned to @${author}`);


### PR DESCRIPTION
Automatically assigns a merged Pull Request to the author who created it.

## Features
- Triggers only when a PR is merged
- Automatically assigns the PR to the user who raised it
- Uses `github-actions[bot]` to perform the assignment
- Safe: does not change assignments for unmerged PRs
- Helps maintain accurate ownership and tracking of merged PRs

Close #235 