### PR TITLE
feat:environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,39 @@ This prevents common "ModuleNotFoundError" or "DatabaseError" crashes that users
 
 ---
 
+## ⚙️ Environment Configuration
+
+SoulSense supports configuration via environment variables with the `SOULSENSE_*` prefix.
+
+### Quick Setup
+
+1. **Copy the example file:**
+   ```bash
+   copy .env.example .env
+   ```
+
+2. **Edit `.env`** to customize settings (optional)
+
+### Supported Variables
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SOULSENSE_ENV` | string | `development` | Environment mode (development/production/test) |
+| `SOULSENSE_DEBUG` | bool | `false` | Enable debug logging |
+| `SOULSENSE_LOG_LEVEL` | string | `INFO` | Log level (DEBUG/INFO/WARNING/ERROR) |
+| `SOULSENSE_DB_PATH` | string | `data/soulsense.db` | Custom database file path |
+| `SOULSENSE_ENABLE_JOURNAL` | bool | `true` | Enable/disable journal feature |
+| `SOULSENSE_ENABLE_ANALYTICS` | bool | `true` | Enable/disable analytics feature |
+
+### Configuration Priority
+
+1. **Environment variables** (highest priority)
+2. **`.env` file** (loaded automatically if present)
+3. **`config.json`** file
+4. **Built-in defaults** (lowest priority)
+
+> **Note:** No configuration is required for normal usage. The application works out-of-the-box with sensible defaults.
+
 ---
 
 ## 🛠 Technologies Used

--- a/app/db.py
+++ b/app/db.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.config import DATABASE_URL, DB_PATH
+from app.config import DATABASE_URL, DB_PATH, BASE_DIR
 from app.exceptions import DatabaseError
 
 # Configure logger

--- a/app/ml/bias_checker.py
+++ b/app/ml/bias_checker.py
@@ -9,8 +9,9 @@ import os
 from datetime import datetime
 
 class SimpleBiasChecker:
-    def __init__(self, db_path="db/soulsense.db"):
-        self.db_path = db_path
+    def __init__(self, db_path=None):
+        from app.config import DB_PATH
+        self.db_path = db_path if db_path is not None else DB_PATH
     
     def check_age_bias(self):
         """Simple check: Are scores different across age groups?"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,6 @@ seaborn==0.13.2
 # Admin CLI
 tabulate==0.9.0
 alembic==1.14.0
+
+# Configuration
+python-dotenv==1.0.0

--- a/scripts/age_group_analytics_demo.py
+++ b/scripts/age_group_analytics_demo.py
@@ -62,17 +62,16 @@ def analyze_emotional_trends():
     print("EMOTIONAL TRENDS BY AGE GROUP")
     print("="*70)
     
-    # Check which databases exist
-    db_paths = ["soulsense_db", "db/soulsense.db", "db/soulsense_db"]
-    available_dbs = [db for db in db_paths if os.path.exists(db)]
+    # Get database path from config
+    from app.config import DB_PATH
     
-    if not available_dbs:
+    if not os.path.exists(DB_PATH):
         print("\n⚠ No database found. Please run the application first to generate data.")
         return
     
-    print(f"\nAnalyzing database: {available_dbs[0]}")
+    print(f"\nAnalyzing database: {DB_PATH}")
     
-    with EDAExporter(available_dbs[0]) as exporter:
+    with EDAExporter(DB_PATH) as exporter:
         # First, ensure all records have detailed age groups
         print("\n1. Ensuring data integrity...")
         results = exporter.backfill_detailed_age_groups()
@@ -141,16 +140,15 @@ def demonstrate_data_export():
     print("DATA EXPORT FOR EDA")
     print("="*70)
     
-    db_paths = ["soulsense_db", "db/soulsense.db", "db/soulsense_db"]
-    available_dbs = [db for db in db_paths if os.path.exists(db)]
+    from app.config import DB_PATH
     
-    if not available_dbs:
+    if not os.path.exists(DB_PATH):
         print("\n⚠ No database found.")
         return
     
-    print(f"\nUsing database: {available_dbs[0]}")
+    print(f"\nUsing database: {DB_PATH}")
     
-    with EDAExporter(available_dbs[0]) as exporter:
+    with EDAExporter(DB_PATH) as exporter:
         dataset = exporter.get_eda_dataset()
         
         if dataset:

--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -42,8 +42,9 @@ class SyntheticDataGenerator:
         self.start_date = datetime.strptime(start_date, '%Y-%m-%d')
         self.end_date = datetime.strptime(end_date, '%Y-%m-%d')
         
-        # Database path
-        self.db_path = Path(__file__).parent.parent / 'db' / 'soulsense.db'
+        # Database path from centralized config
+        from app.config import DB_PATH
+        self.db_path = Path(DB_PATH)
         print(f"USING DB: {self.db_path}")
         
         # Emotional patterns for realistic data generation

--- a/scripts/ml_training_pipeline.py
+++ b/scripts/ml_training_pipeline.py
@@ -256,17 +256,21 @@ class MLTrainingPipeline:
         
         return X, y
     
-    def load_data_from_db(self, db_path: str = "db/soulsense.db") -> Tuple[np.ndarray, np.ndarray]:
+    def load_data_from_db(self, db_path: str = None) -> Tuple[np.ndarray, np.ndarray]:
         """
         Load training data from the database.
         
         Args:
-            db_path: Path to the SQLite database
+            db_path: Path to the SQLite database (uses config default if None)
             
         Returns:
             Tuple of (features, labels) or None if insufficient data
         """
         import sqlite3
+        from app.config import DB_PATH as DEFAULT_DB_PATH
+        
+        if db_path is None:
+            db_path = DEFAULT_DB_PATH
         
         logger.info(f"Loading data from {db_path}...")
         

--- a/scripts/train_real_model.py
+++ b/scripts/train_real_model.py
@@ -12,9 +12,12 @@ import sys
 # Configure Logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+# Add parent dir for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.config import DB_PATH, MODELS_DIR
+
 # Constants
-DB_PATH = os.path.join("db", "soulsense.db")
-MODELS_DIR = "models"
 MIN_RECORDS_REQUIRED = 100
 
 def get_db_connection():

--- a/scripts/visualize_data.py
+++ b/scripts/visualize_data.py
@@ -7,7 +7,8 @@ import sys
 # Add parent dir to path to import app modules if needed
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-DB_PATH = os.path.join("db", "soulsense.db")
+from app.config import DB_PATH
+
 OUTPUT_DIR = os.path.join("docs", "images")
 OUTPUT_FILE = os.path.join(OUTPUT_DIR, "training_data_distribution.png")
 

--- a/seed_db.py
+++ b/seed_db.py
@@ -8,8 +8,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from app.auth import AuthManager
-
-DB_PATH = os.path.join("db", "soulsense.db")
+from app.config import DB_PATH
 
 # Initialize AuthManager
 auth_manager = AuthManager()


### PR DESCRIPTION
## 📌 Description
Implements config-based environment settings to separate configuration values from application logic.

This PR adds environment variable support with `SOULSENSE_*` prefix, allowing configuration of paths, feature toggles, and settings without code changes. It also refactors hardcoded database paths across multiple files to use the centralized configuration.

Fixes: #326 

---

## 🔧 Type of Change
Please mark the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] ♻️ Refactor / Code cleanup
- [ ] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?
Describe the tests you ran to verify your changes.

- [x] Manual testing
- [x] Automated tests
- [ ] Not tested (please explain why)

---

## 📸 Screenshots (if applicable)
N/A

---

## 📋 Changes Made

### Core Changes

| File | Change |
|------|--------|
| `app/config.py` | Added `get_env_var()` helper, `python-dotenv` integration, env var support |
| `requirements.txt` | Added `python-dotenv==1.0.0` |
| `README.md` | Added "Environment Configuration" documentation section |

### Hardcoded Path Refactoring

| File | Change |
|------|--------|
| `seed_db.py` | Use `DB_PATH` from `app.config` |
| `scripts/visualize_data.py` | Use `DB_PATH` from `app.config` |
| `scripts/train_real_model.py` | Use `DB_PATH` and `MODELS_DIR` from `app.config` |
| `scripts/ml_training_pipeline.py` | Use `DB_PATH` from `app.config` as default |
| `scripts/generate_synthetic_data.py` | Use `DB_PATH` from `app.config` |
| `scripts/age_group_analytics_demo.py` | Use `DB_PATH` from `app.config` |
| `app/ml/bias_checker.py` | Use `DB_PATH` from `app.config` as default |

---

## ✅ Checklist
Please confirm the following:

- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes
- **Backward Compatible**: Existing `.env.example` file already documented these variables; now they actually work
- **Zero Configuration Required**: App works out-of-the-box with sensible defaults
- **Graceful Fallback**: If `python-dotenv` is not installed, the app continues to work (env vars can still be set directly)