### PR TITLE
Scaffold FastAPI project (issue #389)

### DIFF
--- a/backend/fastapi/README.md
+++ b/backend/fastapi/README.md
@@ -1,0 +1,23 @@
+FastAPI scaffold
+
+This folder contains a minimal FastAPI application scaffold.
+
+Run locally:
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # or .venv\\Scripts\\activate on Windows
+pip install -r requirements.txt
+```
+
+2. Start the app:
+
+```bash
+uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
+```
+
+Endpoints:
+- GET /health
+- GET /welcome

--- a/backend/fastapi/app/__init__.py
+++ b/backend/fastapi/app/__init__.py
@@ -1,0 +1,3 @@
+"""FastAPI app package"""
+
+__all__ = ["main", "routers", "services", "models", "config"]

--- a/backend/fastapi/app/config.py
+++ b/backend/fastapi/app/config.py
@@ -1,0 +1,23 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    app_env: str = "development"
+    host: str = "127.0.0.1"
+    port: int = 8000
+    debug: bool = True
+    welcome_message: str = "Welcome to Soul Sense!"
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings

--- a/backend/fastapi/app/main.py
+++ b/backend/fastapi/app/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+from .config import get_settings
+from .routers import health
+
+settings = get_settings()
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="SoulSense FastAPI (scaffold)")
+    app.include_router(health.router)
+
+    @app.on_event("startup")
+    async def startup_event():
+        app.state.settings = settings
+
+    return app
+
+
+app = create_app()

--- a/backend/fastapi/app/models/schemas.py
+++ b/backend/fastapi/app/models/schemas.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    status: str

--- a/backend/fastapi/app/routers/__init__.py
+++ b/backend/fastapi/app/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import health
+
+__all__ = ["health"]

--- a/backend/fastapi/app/routers/health.py
+++ b/backend/fastapi/app/routers/health.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Request
+from ..models.schemas import HealthResponse
+from ..services.example_service import get_welcome
+
+router = APIRouter()
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health() -> dict:
+    return {"status": "ok"}
+
+
+@router.get("/welcome")
+async def welcome(request: Request) -> dict:
+    settings = getattr(request.app.state, "settings", None)
+    return {"message": get_welcome(settings)}

--- a/backend/fastapi/app/services/example_service.py
+++ b/backend/fastapi/app/services/example_service.py
@@ -1,0 +1,4 @@
+def get_welcome(settings) -> str:
+    if settings and getattr(settings, "welcome_message", None):
+        return settings.welcome_message
+    return "Welcome!"

--- a/backend/fastapi/requirements.txt
+++ b/backend/fastapi/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.95.0
+uvicorn[standard]>=0.22.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
fixes #389

Add a minimal FastAPI scaffold with modular structure (routers, services, models) and environment-based configuration using Pydantic BaseSettings. This provides a starting point for backend APIs and environment separation.
Files added

[README.md](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[requirements.txt](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[.env.example](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[__init__.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[main.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[config.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[health.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[example_service.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[schemas.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
How to run locally

Testing / Verification

GET [http://127.0.0.1:8000/health](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → returns [{ "status": "ok" }](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
GET [http://127.0.0.1:8000/welcome](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → returns { "message": "<welcome message>" }
Edit .env or copy .env.example to .env to change WELCOME_MESSAGE or other settings.
Notes for reviewer

[config.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) uses Pydantic BaseSettings and .env for environment separation.
routers, [services](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [models](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) folders show recommended modular layout; example_service is a placeholder.
Intended as a scaffold only — authentication, DB, tests, and CI/CD are next steps.
If you prefer stricter defaults (e.g., production settings), I can add separate env files and an env-loader utility.
Related issue: #389

