### PR TITLE
added terms and condition checkbox

### DIFF
--- a/frontend-web/src/app/register/page.tsx
+++ b/frontend-web/src/app/register/page.tsx
@@ -218,6 +218,46 @@ export default function RegisterPage() {
                   {showPassword ? 'Hide Password' : 'Show Password'}
                 </Button>
               </div>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: 0.45 }}
+            >
+              <FormField control={methods.control} name="acceptTerms">
+                {(fieldProps) => (
+                  <div className="flex items-start space-x-3">
+                    <input
+                      type="checkbox"
+                      id="acceptTerms"
+                      checked={fieldProps.value || false}
+                      onChange={(e) => fieldProps.onChange(e.target.checked)}
+                      className="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
+                    />
+                    <label
+                      htmlFor="acceptTerms"
+                      className="text-sm text-muted-foreground cursor-pointer"
+                    >
+                      I agree to the{' '}
+                      <Link
+                        href="/terms"
+                        className="text-primary hover:text-primary/80 underline"
+                        target="_blank"
+                      >
+                        Terms & Conditions
+                      </Link>
+                    </label>
+                  </div>
+                )}
+              </FormField>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: 0.5 }}
+            >
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? (
                   <>


### PR DESCRIPTION
closes #561 
## 📌 Description
Require Terms & Conditions Acceptance During Signup. This PR adds a mandatory Terms & Conditions checkbox to the frontend web registration form that users must accept before creating an account.

Fixes: #561 

---

## 🔧 Type of Change
Please mark the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [x] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Not tested (please explain why)

---

## 📸 Screenshots (if applicable)
<img width="801" height="487" alt="image" src="https://github.com/user-attachments/assets/6f5f0064-5606-4cfb-9281-d89df6cf36d3" />

---

## ✅ Checklist
Please confirm the following:

- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking change