### PR TITLE
feat: add email domain typo suggestions (Issue #617)

### DIFF
--- a/app/auth/app_auth.py
+++ b/app/auth/app_auth.py
@@ -124,11 +124,16 @@ class AppAuth:
         # Email validation error label for login (only shows for email-like input)
         login_email_error_label = tk.Label(entry_frame, text="", font=("Segoe UI", 8), 
                                            bg=self.app.colors["bg"], fg="#EF4444")
-        login_email_error_label.pack(anchor="w", pady=(0, 10))
+        login_email_error_label.pack(anchor="w", pady=(0, 2))
+        
+        # Email domain suggestion label (Issue #617)
+        login_email_suggestion_label = tk.Label(entry_frame, text="", font=("Segoe UI", 8, "italic"), 
+                                                bg=self.app.colors["bg"], fg="#3B82F6")
+        login_email_suggestion_label.pack(anchor="w", pady=(0, 5))
         
         # Real-time email validation for login (only if input looks like an email)
         def validate_login_email_realtime(event=None):
-            from app.validation import validate_email_strict
+            from app.validation import validate_email_strict, suggest_email_domain
             identifier = username_entry.get().strip()
             # Only validate if it looks like an email (contains @)
             if '@' in identifier:
@@ -137,11 +142,20 @@ class AppAuth:
                     login_email_error_label.config(text="")
                 else:
                     login_email_error_label.config(text=error_msg)
+                
+                # Check for domain suggestions (Issue #617)
+                suggestion = suggest_email_domain(identifier)
+                if suggestion:
+                    login_email_suggestion_label.config(text=f"💡 Did you mean {suggestion}?")
+                else:
+                    login_email_suggestion_label.config(text="")
             else:
                 login_email_error_label.config(text="")
+                login_email_suggestion_label.config(text="")
         
         username_entry.bind("<KeyRelease>", validate_login_email_realtime)
         username_entry.bind("<FocusOut>", validate_login_email_realtime)
+
 
         tk.Label(entry_frame, text="Password", font=("Segoe UI", 10, "bold"),
                  bg=self.app.colors["bg"], fg=self.app.colors["text_primary"]).pack(anchor="w")
@@ -574,12 +588,18 @@ class AppAuth:
                                      bg=self.app.colors.get("surface", "#FFFFFF"), fg="#EF4444")
         email_error_label.pack(anchor="w")
         
+        # Email domain suggestion label (Issue #617)
+        email_suggestion_label = tk.Label(em_frame, text="", font=("Segoe UI", 8, "italic"), 
+                                          bg=self.app.colors.get("surface", "#FFFFFF"), fg="#3B82F6")
+        email_suggestion_label.pack(anchor="w")
+        
         # Real-time email validation function
         def validate_email_realtime(event=None):
-            from app.validation import validate_email_strict
+            from app.validation import validate_email_strict, suggest_email_domain
             email = email_entry.get().strip()
             if not email:
                 email_error_label.config(text="")
+                email_suggestion_label.config(text="")
                 email_entry.config(highlightbackground=self.app.colors.get("border", "#E2E8F0"), highlightcolor=self.app.colors.get("border", "#E2E8F0"))
                 return
             is_valid, error_msg = validate_email_strict(email)
@@ -589,10 +609,18 @@ class AppAuth:
             else:
                 email_error_label.config(text=error_msg)
                 email_entry.config(highlightbackground="#EF4444", highlightcolor="#EF4444")
+            
+            # Check for domain suggestions (Issue #617)
+            suggestion = suggest_email_domain(email)
+            if suggestion:
+                email_suggestion_label.config(text=f"💡 Did you mean {suggestion}?")
+            else:
+                email_suggestion_label.config(text="")
         
         # Bind validation to key release and focus out events
         email_entry.bind("<KeyRelease>", validate_email_realtime)
         email_entry.bind("<FocusOut>", validate_email_realtime)
+
 
         # Row 2: Age & Gender
         ag_frame = tk.Frame(form_frame, bg=self.app.colors.get("surface", "#FFFFFF"))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from app.validation import (
     sanitize_text, validate_required, validate_length,
     validate_email, validate_email_strict, validate_phone, validate_age,
-    validate_range, validate_dob,
+    validate_range, validate_dob, suggest_email_domain,
     AGE_MIN, AGE_MAX
 )
 
@@ -115,3 +115,46 @@ def test_validate_dob():
     assert validate_dob(today)[0] is False # Too young/Future
     assert validate_dob("invalid")[0] is False
     assert validate_dob("")[0] is True
+
+
+def test_suggest_email_domain():
+    """Test email domain suggestion for common typos (Issue #617)."""
+    
+    # Gmail typos
+    assert suggest_email_domain("user@gmial.com") == "user@gmail.com"
+    assert suggest_email_domain("user@gmal.com") == "user@gmail.com"
+    assert suggest_email_domain("user@gmali.com") == "user@gmail.com"
+    assert suggest_email_domain("user@gnail.com") == "user@gmail.com"
+    
+    # Yahoo typos
+    assert suggest_email_domain("user@yaho.com") == "user@yahoo.com"
+    assert suggest_email_domain("user@yahooo.com") == "user@yahoo.com"
+    assert suggest_email_domain("user@tahoo.com") == "user@yahoo.com"
+    
+    # Hotmail typos
+    assert suggest_email_domain("user@hotmal.com") == "user@hotmail.com"
+    assert suggest_email_domain("user@hotmai.com") == "user@hotmail.com"
+    assert suggest_email_domain("user@hotmial.com") == "user@hotmail.com"
+    
+    # Outlook typos
+    assert suggest_email_domain("user@outlok.com") == "user@outlook.com"
+    assert suggest_email_domain("user@outloo.com") == "user@outlook.com"
+    
+    # Valid domains should return None (no suggestion needed)
+    assert suggest_email_domain("user@gmail.com") is None
+    assert suggest_email_domain("user@yahoo.com") is None
+    assert suggest_email_domain("user@hotmail.com") is None
+    assert suggest_email_domain("user@outlook.com") is None
+    assert suggest_email_domain("user@icloud.com") is None
+    
+    # Unknown/custom domains should return None
+    assert suggest_email_domain("user@company.com") is None
+    assert suggest_email_domain("user@mydomain.org") is None
+    
+    # Edge cases
+    assert suggest_email_domain("") is None
+    assert suggest_email_domain("invalid") is None
+    assert suggest_email_domain("user@") is None
+    assert suggest_email_domain("@domain.com") is None
+    assert suggest_email_domain("user@@gmail.com") is None
+


### PR DESCRIPTION
closes #617 
## 📌 Description
Implemented email domain typo detection and suggestion for common misspellings. When users enter emails with typos like @gmial.com, the system suggests the correct domain.

Fixes: #617 

---

## 🔧 Type of Change
Please mark the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [x] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?
Describe the tests you ran to verify your changes.

- [x] Manual testing
- [x] Automated tests
- [ ] Not tested (please explain why)

---

## 📸 Screenshots (if applicable)
<img width="828" height="473" alt="image" src="https://github.com/user-attachments/assets/91ae438a-321e-43f7-bc6f-ddfd93808e3c" />

---

## ✅ Checklist
Please confirm the following:

- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---