### PR TITLE
feat(types): add exam results interfaces

### DIFF
--- a/frontend-web/src/types/results.ts
+++ b/frontend-web/src/types/results.ts
@@ -1,0 +1,31 @@
+export interface CategoryScore {
+    name: string;
+    score: number;
+    max_score: number;
+    description?: string;
+}
+
+export interface Recommendation {
+    id: number;
+    title: string;
+    description: string;
+    category?: string;
+    priority?: "high" | "medium" | "low";
+}
+
+export interface ExamResult {
+    id: number;
+    overall_score: number;
+    categories: CategoryScore[];
+    recommendations: Recommendation[];
+    completed_at: string;
+    duration_seconds: number;
+    reflection?: string;
+}
+
+export interface ResultsHistory {
+    results: ExamResult[];
+    total: number;
+    page: number;
+    per_page: number;
+}


### PR DESCRIPTION
closes #719
fixes #719 
## 📌 Description
This PR creates a new TypeScript type definition file [frontend-web/src/types/results.ts](cci:7://file:///c:/Users/DELL/OneDrive/Documents/SOUL_SENSE_EXAM/frontend-web/src/types/results.ts:0:0-0:0). It introduces strict interfaces for exam results, category scores, and recommendations to align the frontend with the API response structure.

This ensures type safety when fetching and displaying exam results.

**New Interfaces:**
- [ExamResult](cci:2://file:///c:/Users/DELL/OneDrive/Documents/SOUL_SENSE_EXAM/frontend-web/src/types/results.ts:15:0-23:1)
- [CategoryScore](cci:2://file:///c:/Users/DELL/OneDrive/Documents/SOUL_SENSE_EXAM/frontend-web/src/types/results.ts:0:0-5:1)
- [Recommendation](cci:2://file:///c:/Users/DELL/OneDrive/Documents/SOUL_SENSE_EXAM/frontend-web/src/types/results.ts:7:0-13:1)
- [ResultsHistory](cci:2://file:///c:/Users/DELL/OneDrive/Documents/SOUL_SENSE_EXAM/frontend-web/src/types/results.ts:25:0-30:1)

Fixes: #719 

---

## 🔧 Type of Change
Please mark the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [ ] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?
Describe the tests you ran to verify your changes.

- [x] Manual testing
- [ ] Automated tests
- [ ] Not tested (please explain why)

**Verification Steps:**
Ran `npx tsc --noEmit` in the `frontend-web` directory to ensure the new interfaces are valid and do not cause any compilation errors. The check passed with 0 errors.

---

## 📸 Screenshots (if applicable)
_N/A - Type definitions only._

---

## ✅ Checklist
Please confirm the following:

- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes
These types are ready to be imported into the Results page and API service hooks.
