### PR TITLE
feat: implement JournalEntryCard component with compact and expanded variants

### DIFF
--- a/frontend-web/src/app/journal-demo/page.tsx
+++ b/frontend-web/src/app/journal-demo/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React from 'react';
+import { JournalEntryCard } from '@/components/journal';
+import { JournalEntry } from '@/types/journal';
+
+const MOCK_ENTRIES: JournalEntry[] = [
+    {
+        id: 1,
+        entry_date: '2024-01-15T10:00:00Z',
+        content: 'Today was a productive day. I managed to finish all my tasks and even had some time for a walk in the park. The weather was beautiful and I felt very peaceful.',
+        mood_score: 8,
+        tags: ['Productive', 'Nature', 'Peaceful'],
+        sentiment_score: 0.8
+    },
+    {
+        id: 2,
+        entry_date: '2024-01-16T18:30:00Z',
+        content: 'Feeling a bit overwhelmed with work. There are so many deadlines approaching and I feel like I am falling behind. I need to take a break soon.',
+        mood_score: 3,
+        tags: ['Work', 'Stress', 'Deadlines'],
+        sentiment_score: -0.6
+    },
+    {
+        id: 3,
+        entry_date: '2024-01-17T09:15:00Z',
+        content: 'Neutral day. Just regular routines. Nothing much happened, but that is okay sometimes.',
+        mood_score: 5,
+        tags: ['Routine'],
+        sentiment_score: 0.1
+    }
+];
+
+export default function JournalDemoPage() {
+    const handleClick = (entry: JournalEntry) => {
+        alert(`Clicked entry: ${entry.id}`);
+    };
+
+    return (
+        <div className="container mx-auto py-12 px-4 max-w-4xl">
+            <h1 className="text-4xl font-bold mb-8 text-center bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+                Journal Entry Card Demo
+            </h1>
+
+            <section className="mb-12">
+                <h2 className="text-2xl font-semibold mb-6 border-b pb-2">Compact Variant</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {MOCK_ENTRIES.map(entry => (
+                        <JournalEntryCard
+                            key={entry.id}
+                            entry={entry}
+                            variant="compact"
+                            onClick={handleClick}
+                        />
+                    ))}
+                </div>
+            </section>
+
+            <section>
+                <h2 className="text-2xl font-semibold mb-6 border-b pb-2">Expanded Variant</h2>
+                <div className="space-y-6">
+                    {MOCK_ENTRIES.map(entry => (
+                        <JournalEntryCard
+                            key={entry.id}
+                            entry={entry}
+                            variant="expanded"
+                            onClick={handleClick}
+                        />
+                    ))}
+                </div>
+            </section>
+        </div>
+    );
+}

--- a/frontend-web/src/components/journal/entry-card.module.css
+++ b/frontend-web/src/components/journal/entry-card.module.css
@@ -1,0 +1,132 @@
+.card {
+    position: relative;
+    background-color: var(--card, white);
+    border: 1px solid var(--border, #e2e8f0);
+    border-radius: var(--radius-xl, 12px);
+    padding: var(--space-4, 16px);
+    transition: all var(--duration-300, 300ms) var(--ease-spring);
+    cursor: pointer;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3, 12px);
+    box-shadow: var(--shadow-sm);
+}
+
+.card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--brand-primary-300, #99a7f7);
+}
+
+.card.compact {
+    padding: var(--space-3, 12px);
+    gap: var(--space-2, 8px);
+}
+
+.card.expanded {
+    padding: var(--space-6, 24px);
+    gap: var(--space-4, 16px);
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.date {
+    font-size: var(--text-xs, 12px);
+    color: var(--muted-foreground, #64748b);
+    font-weight: var(--font-medium, 500);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider, 0.05em);
+}
+
+.moodContainer {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2, 8px);
+    background: var(--brand-primary-50, #f0f7ff);
+    padding: var(--space-1, 4px) var(--space-2, 8px);
+    border-radius: var(--radius-full, 9999px);
+}
+
+.moodEmoji {
+    font-size: var(--text-lg, 18px);
+}
+
+.moodRating {
+    font-size: var(--text-xs, 12px);
+    font-weight: var(--font-bold, 700);
+    color: var(--brand-primary-700, #3b82f6);
+}
+
+.content {
+    font-size: var(--text-sm, 14px);
+    line-height: var(--leading-relaxed, 1.625);
+    color: var(--foreground, #0f172a);
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.compact .content {
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+}
+
+.expanded .content {
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+}
+
+.tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2, 8px);
+}
+
+.tag {
+    font-size: var(--text-xs, 12px);
+    padding: var(--space-0-5, 2px) var(--space-2, 8px);
+    background-color: var(--brand-primary-100, #dbeafe);
+    color: var(--brand-primary-800, #1e40af);
+    border-radius: var(--radius-md, 6px);
+    font-weight: var(--font-medium, 500);
+}
+
+.sentimentIndicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 4px;
+    height: 100%;
+}
+
+.sentiment-positive {
+    background-color: var(--success-500, #10b981);
+}
+
+.sentiment-neutral {
+    background-color: var(--warning-500, #f59e0b);
+}
+
+.sentiment-negative {
+    background-color: var(--destructive, #ef4444);
+}
+
+.footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: auto;
+}
+
+.arrow {
+    color: var(--brand-primary-400, #60a5fa);
+    transition: transform var(--duration-200);
+}
+
+.card:hover .arrow {
+    transform: translateX(4px);
+}

--- a/frontend-web/src/components/journal/entry-card.tsx
+++ b/frontend-web/src/components/journal/entry-card.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React from 'react';
+import { format, parseISO } from 'date-fns';
+import { motion } from 'framer-motion';
+import { ChevronRight } from 'lucide-react';
+import { JournalEntry } from '@/types/journal';
+import { cn } from '@/lib/utils';
+import styles from './entry-card.module.css';
+
+interface EntryCardProps {
+    entry: JournalEntry;
+    onClick?: (entry: JournalEntry) => void;
+    variant?: 'compact' | 'expanded';
+    className?: string;
+}
+
+const getMoodEmoji = (score: number | undefined): string => {
+    if (score === undefined) return '😐';
+    if (score <= 2) return '😢';
+    if (score <= 4) return '😕';
+    if (score <= 6) return '😐';
+    if (score <= 8) return '🙂';
+    return '😄';
+};
+
+const getSentimentColorClass = (score: number | undefined): string => {
+    if (score === undefined) return styles['sentiment-neutral'];
+    if (score > 0.3) return styles['sentiment-positive'];
+    if (score < -0.3) return styles['sentiment-negative'];
+    return styles['sentiment-neutral'];
+};
+
+export const JournalEntryCard: React.FC<EntryCardProps> = ({
+    entry,
+    onClick,
+    variant = 'compact',
+    className,
+}) => {
+    const {
+        entry_date,
+        content,
+        mood_score,
+        tags = [],
+        sentiment_score,
+    } = entry;
+
+    const formattedDate = React.useMemo(() => {
+        try {
+            return format(parseISO(entry_date), 'MMMM d, yyyy');
+        } catch (e) {
+            return entry_date;
+        }
+    }, [entry_date]);
+
+    const moodEmoji = getMoodEmoji(mood_score);
+    const sentimentClass = getSentimentColorClass(sentiment_score);
+
+    return (
+        <motion.div
+            layout
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            whileHover={{ scale: 1.01 }}
+            whileTap={{ scale: 0.99 }}
+            onClick={() => onClick?.(entry)}
+            className={cn(
+                styles.card,
+                variant === 'compact' ? styles.compact : styles.expanded,
+                className
+            )}
+        >
+            <div className={cn(styles.sentimentIndicator, sentimentClass)} />
+
+            <div className={styles.header}>
+                <span className={styles.date}>{formattedDate}</span>
+                <div className={styles.moodContainer}>
+                    <span className={styles.moodEmoji}>{moodEmoji}</span>
+                    {mood_score !== undefined && (
+                        <span className={styles.moodRating}>{mood_score}/10</span>
+                    )}
+                </div>
+            </div>
+
+            <p className={styles.content}>
+                {content}
+            </p>
+
+            {tags.length > 0 && (
+                <div className={styles.tags}>
+                    {tags.slice(0, variant === 'compact' ? 3 : 6).map((tag, idx) => (
+                        <span key={idx} className={styles.tag}>
+                            {tag}
+                        </span>
+                    ))}
+                    {variant === 'compact' && tags.length > 3 && (
+                        <span className={styles.tag}>+{tags.length - 3}</span>
+                    )}
+                </div>
+            )}
+
+            <div className={styles.footer}>
+                <ChevronRight className={styles.arrow} size={18} />
+            </div>
+        </motion.div>
+    );
+};

--- a/frontend-web/src/components/journal/index.ts
+++ b/frontend-web/src/components/journal/index.ts
@@ -1,0 +1,4 @@
+export { JournalEntryCard } from './entry-card';
+export { MoodSlider } from './mood-slider';
+export { MoodTrend } from './mood-trend';
+export { TagSelector } from './tag-selector';


### PR DESCRIPTION
Closes #745

## 📌 Description
This PR implements the `JournalEntryCard` component for the Soul Sense application. This component is designed to display high-quality summaries of past journal entries in lists, featuring responsive layouts and emotional sentiment visualization.

**Key Changes:**
- Created `JournalEntryCard` with `'compact'` and `'expanded'` variants.
- Integrated mood emoji mapping (1-10) and dynamic sentiment indicators.
- Implemented premium UI interactions using `framer-motion` (hover elevation, layout morphing).
- Added a demo page at `/journal-demo` for visual verification.
- Enforced clean architecture via CSS Modules and barrel exports.

Fixes: #745 

---

## 🔧 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [x] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?
- [x] **Manual testing**: Verified all variants on the `/journal-demo` page. Checked truncation logic, mood emoji accuracy, and responsive behavior.
- [ ] Automated tests
- [ ] Not tested (please explain why)

---

## 📸 Screenshots (if applicable)
*(Screenshots can be viewed by running the application and navigating to /journal-demo)*

---

## ✅ Checklist
- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes
- Uses `date-fns` for robust date formatting.
- Sentiment indicator uses a subtle left-border color accent (Green for positive, Amber for neutral, Red for negative).
- Content truncation uses `line-clamp` for clean multi-line ellipsis.

---