### PR TITLE
Token-790

### DIFF
--- a/frontend-web/src/app/(app)/layout.tsx
+++ b/frontend-web/src/app/(app)/layout.tsx
@@ -1,22 +1,11 @@
 'use client';
 
 import * as React from 'react';
-import { useEffect } from 'react';
-import { useRouter, usePathname } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { Sidebar, Header } from '@/components/app';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
-  const router = useRouter();
-  const pathname = usePathname();
-
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      const callbackUrl = encodeURIComponent(pathname);
-      router.push(`/login?callbackUrl=${callbackUrl}`);
-    }
-  }, [isLoading, isAuthenticated, router, pathname]);
 
   if (isLoading) {
     return (

--- a/frontend-web/src/app/layout.tsx
+++ b/frontend-web/src/app/layout.tsx
@@ -50,10 +50,6 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
-  viewport: {
-    width: 'device-width',
-    initialScale: 1,
-    maximumScale: 5,
 };
 
 export const viewport: Viewport = {

--- a/frontend-web/src/middleware.ts
+++ b/frontend-web/src/middleware.ts
@@ -3,11 +3,39 @@ import type { NextRequest } from 'next/server';
 
 /**
  * Middleware to handle global request/response logic.
- * Currently serves as a scalable boilerplate for future auth or
- * internationalization logic.
+ * Implements route protection for authenticated routes.
  */
 export function middleware(request: NextRequest) {
-  // Add authentication or redirection logic here
+  const { pathname } = request.nextUrl;
+
+  // Define protected routes
+  const protectedPrefixes = ["/app", "/admin"];
+
+  // Define auth routes
+  const authRoutes = ["/login", "/register", "/forgot-password"];
+
+  // Read authentication token from cookies
+  const token = request.cookies.get('refresh_token')?.value;
+
+  // Check if current path is protected
+  const isProtected = protectedPrefixes.some(prefix => pathname.startsWith(prefix));
+
+  // Check if current path is an auth route
+  const isAuthRoute = authRoutes.some(route => pathname.startsWith(route));
+
+  if (isProtected && !token) {
+    // Redirect unauthenticated users to login
+    const loginUrl = new URL('/login', request.url);
+    // Preserve the original URL as callback
+    loginUrl.searchParams.set('callbackUrl', pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  if (isAuthRoute && token) {
+    // Redirect authenticated users away from auth pages to dashboard
+    return NextResponse.redirect(new URL('/app/dashboard', request.url));
+  }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
Closes #790 
Fixes #790 

## Description
This PR implements true server-side route protection using Next.js middleware, replacing the previous client-side authentication checks that caused content flash and security vulnerabilities.

Problem Solved
Previously, route protection relied exclusively on client-side [useAuth](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) React hook in the [layout.tsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html). This caused:

Content Flash: Protected pages' HTML was sent to unauthenticated users' browsers
Security Risk: Sensitive layout skeletons rendered before React hydration detected missing session
UX Issues: Forceful redirects after page load
Technical Implementation
Modified [middleware.ts](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html):

Added route protection logic intercepting requests before rendering
Checks for [refresh_token](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) HttpOnly cookie set by backend during authentication
Protected routes: [/app/*](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), /admin/*
Auth routes: [/login](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [/register](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [/forgot-password](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Redirects unauthenticated users to [/login](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with callback URL preservation
Redirects authenticated users away from auth pages to [/app/dashboard](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated [layout.tsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html):

Removed client-side [useEffect](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) authentication redirect logic
Eliminated conflicting redirect mechanisms
Layout now assumes middleware has handled authentication
Fixed [layout.tsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html):

Resolved syntax error in viewport configuration
## Key Features
Edge-Side Protection: Runs on Next.js Edge runtime before page rendering
HTTP 307 Redirects: Proper temporary redirect status codes
Callback URL Support: Preserves original destination for post-login redirect
Static Asset Bypass: Middleware excludes API routes, static files, and images
HttpOnly Cookie Security: Uses backend-set [refresh_token](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) cookie for validation
Acceptance Criteria ✅
 Middleware intercepts unauthenticated access to [/app/dashboard](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and redirects to [/login](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with HTTP 307 before page render
 Authenticated users access [/app/dashboard](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) seamlessly
 Static assets (/_next/, /images/) load without redirect loops
 No content flash on protected routes
 Client-side redirect logic removed from layout
Testing Instructions
Start the frontend server:

## Test unauthenticated access:

Open incognito window
Navigate to http://localhost:3000/app/dashboard
Verify Network tab shows HTTP 307 redirect to [/login](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Confirm no dashboard HTML is downloaded
Test authenticated access:

Login through normal flow
Access [/app/dashboard](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - should load immediately
Visit [/login](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - should redirect to [/app/dashboard](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Test static assets:

Verify images, CSS, JS load without triggering middleware
Edge Cases Handled
Server Restarts: Middleware doesn't rely on localStorage, uses HttpOnly cookies
Multiple Sessions: Backend handles session validation
Callback URLs: Original destination preserved in redirect
API Routes: Excluded from middleware processing
Risks & Blockers
Cookie Name Alignment: Assumes [refresh_token](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) cookie from backend; if backend changes cookie structure, middleware may need updates
Merge Conflicts: Layout changes may conflict with concurrent styling PRs
Middleware Runtime: Limited to Edge runtime capabilities (no Node.js libraries)
## Files Changed
[middleware.ts](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Added route protection logic
[layout.tsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Removed client-side redirects
[layout.tsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Fixed syntax error
Related Issues
Closes #790 