### PR TITLE
Implemented Current User-791

### DIFF
--- a/backend/fastapi/api/routers/auth.py
+++ b/backend/fastapi/api/routers/auth.py
@@ -60,6 +60,21 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], db: Se
     user = db.query(User).filter(User.username == username).first()
     if user is None:
         raise credentials_exception
+    
+    # Check if user is active
+    if not getattr(user, 'is_active', True):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Inactive user"
+        )
+    
+    # Check if user is deleted
+    if getattr(user, 'is_deleted', False) or getattr(user, 'deleted_at', None) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User account is deleted"
+        )
+    
     return user
 
 


### PR DESCRIPTION
Closes #791
Fixes #791 

## Context & Objective
The [get_current_user](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) dependency function in [auth.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was missing critical checks for user status flags. Previously, users with is_active=False or is_deleted=True could still make authenticated API requests with valid JWTs until token expiration. This PR enforces database-level status flags on every authenticated request by adding explicit checks in the core authentication dependency.

## Technical Implementation
File Modified: [auth.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Function: [get_current_user](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (lines ~40-80)
## Changes:
Added check for is_active flag: Raises [400 Bad Request](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) if user is inactive
Added check for is_deleted flag and deleted_at timestamp: Raises 403 Forbidden if user account is deleted
Used [getattr()](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with defensive defaults to prevent AttributeError exceptions
Checks are performed immediately after database query, before returning the user object
## Code Changes
# After user = db.query(User).filter(User.username == username).first()
if user is None:
    raise credentials_exception

# Check if user is active
if not getattr(user, 'is_active', True):
    raise HTTPException(
        status_code=status.HTTP_400_BAD_REQUEST,
        detail="Inactive user"
    )

# Check if user is deleted
if getattr(user, 'is_deleted', False) or getattr(user, 'deleted_at', None) is not None:
    raise HTTPException(
        status_code=status.HTTP_403_FORBIDDEN,
        detail="User account is deleted"
    )

return user
## Acceptance Criteria Met
✅ Users with is_active=False receive [400 Bad Request](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on protected routes
✅ Users with is_deleted=True or deleted_at set receive 403 Forbidden on protected routes
✅ Active users continue to authenticate normally without interference
## Testing Recommendations
Start FastAPI backend and database client
Obtain valid JWT via login endpoint
Manually update user record: UPDATE users SET is_active=false WHERE username='test';
Verify /users/me and other protected endpoints return [400 Bad Request](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Reset and test is_deleted=True for 403 Forbidden response
Confirm active users can still access endpoints
## Edge Cases Considered
Performance: No additional DB queries - checks use already-loaded user object
Frontend Impact: May require updating Next.js apiClient to handle 403 responses (clear session on 403 in addition to 401)
Backward Compatibility: Uses [getattr()](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with sensible defaults for missing attributes
## Risk Mitigation
Defensive programming with [getattr()](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prevents runtime errors if model changes
Status codes chosen to differentiate: 400 for inactive (client-side issue), 403 for deleted (forbidden access)
No breaking changes to existing active user flows
Closes #791

