### PR TITLE
Implementeed Guard Auth Service

### DIFF
--- a/backend/fastapi/api/services/mock_auth_service.py
+++ b/backend/fastapi/api/services/mock_auth_service.py
@@ -23,6 +23,11 @@ from ..root_models import User
 from sqlalchemy.orm import Session
 
 settings = get_settings()
+
+# CRITICAL SECURITY GUARD: Prevent MockAuthService from loading in production
+if settings.ENVIRONMENT == "production":
+    raise RuntimeError("CRITICAL SECURITY VIOLATION: MockAuthService cannot be loaded in a production environment!")
+
 logger = logging.getLogger(__name__)
 
 # Mock users for testing


### PR DESCRIPTION
Closes #830 
Fixes #830 

## Changes Implemented
1. Added ENVIRONMENT Field to Configuration
Added [ENVIRONMENT](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field to [BaseAppSettings](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [config.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added validation for allowed environments: {'development', 'staging', 'production', 'testing'}
Set appropriate [ENVIRONMENT](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) values in each settings class (development, staging, production)
2. Implemented Security Guard in MockAuthService
Added a critical security check in [mock_auth_service.py](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) immediately after settings initialization
The guard raises a [RuntimeError](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) if [settings.ENVIRONMENT == "production"](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), preventing the module from loading in production
3. Enforced Mock Auth Disable in Production
Added a field validator for [mock_auth_mode](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that forcibly sets it to False when [app_env == "production"](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), ensuring the mock authentication cannot be accidentally enabled via environment variables in production
## Testing Results
✅ Import Prevention in Production: Attempting to import [MockAuthService](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in a production environment now raises:

✅ Normal Operation in Development: Import works correctly in development/testing environments

✅ Configuration Integrity: The [ENVIRONMENT](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field properly reflects the application environment

## Security Benefits
Fail-Deadly Protection: Any accidental import of the mock service in production will immediately halt execution
Dependency Injection Safety: Even if someone tries to inject the mock service, the import itself fails
Environment Variable Override Prevention: Mock auth mode is forcibly disabled in production regardless of environment variable settings
The implementation ensures that the Mock Auth Service can never be loaded or used in a production environment, providing the critical security guard requested in the issue.

Closes #830