### PR TITLE
Fix: Replace OTP.type with OTP.purpose and resolve missing created_at column

### DIFF
--- a/app/auth/otp_manager.py
+++ b/app/auth/otp_manager.py
@@ -46,7 +46,7 @@ class OTPManager:
             # 1. Rate Limiting Check
             last_otp = session.query(OTP).filter(
                 OTP.user_id == user_id,
-                OTP.type == purpose
+                OTP.purpose == purpose
             ).order_by(OTP.created_at.desc()).first()
             
             if last_otp:
@@ -63,7 +63,7 @@ class OTPManager:
             new_otp = OTP(
                 user_id=user_id,
                 code_hash=code_hash,
-                type=purpose,
+                purpose=purpose,
                 created_at=datetime.utcnow(),
                 expires_at=datetime.utcnow() + timedelta(minutes=cls.OTP_EXPIRY_MINUTES),
                 is_used=False,
@@ -101,7 +101,7 @@ class OTPManager:
         try:
             otp = session.query(OTP).filter(
                 OTP.user_id == user_id,
-                OTP.type == purpose,
+                OTP.purpose == purpose,
                 OTP.is_used == False,
                 OTP.expires_at > datetime.utcnow()
             ).order_by(OTP.created_at.desc()).first()
@@ -137,7 +137,7 @@ class OTPManager:
         try:
             last_otp = session.query(OTP).filter(
                 OTP.user_id == user_id,
-                OTP.type == purpose
+                OTP.purpose == purpose
             ).order_by(OTP.created_at.desc()).first()
 
             if last_otp:
@@ -164,7 +164,7 @@ class OTPManager:
         try:
             otp = session.query(OTP).filter(
                 OTP.user_id == user_id,
-                OTP.type == purpose,
+                OTP.purpose == purpose,
                 OTP.is_used == False,
                 OTP.is_locked == False,
                 OTP.expires_at > datetime.utcnow()
@@ -203,7 +203,7 @@ class OTPManager:
             # Find the valid OTP
             otp = session.query(OTP).filter(
                 OTP.user_id == user_id,
-                OTP.type == purpose,
+                OTP.purpose == purpose,
                 OTP.is_used == False,
                 OTP.expires_at > datetime.utcnow()
             ).order_by(OTP.created_at.desc()).first()

--- a/app/models.py
+++ b/app/models.py
@@ -105,7 +105,8 @@ class OTP(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     code_hash = Column(String, nullable=False)
-    purpose = Column(String, nullable=False) # e.g. 'PASSWORD_RESET', '2FA'
+    purpose = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
     expires_at = Column(DateTime, nullable=False)
     is_used = Column(Boolean, default=False)
     attempts = Column(Integer, default=0)


### PR DESCRIPTION
## 📌 Description

\`app/auth/otp_manager.py\` referenced \`OTP.type\` and \`OTP.created_at\`, neither of which existed on the \`OTP\` model. The model defines \`purpose\` (not \`type\`) and lacked a \`created_at\` timestamp column.

This caused an \`AttributeError\` at runtime on every call to \`generate_otp\`, \`is_otp_locked\`, \`get_cooldown_remaining\`, and \`verify_otp\`, making the entire OTP system non-functional.

Changes:
- Replaced all \`OTP.type\` references in \`otp_manager.py\` with \`OTP.purpose\`
- Replaced \`type=purpose\` keyword argument in the OTP constructor with \`purpose=purpose\`
- Added \`created_at = Column(DateTime, default=datetime.utcnow)\` to the \`OTP\` model in \`models.py\`

Fixes: #835

---

## 🔧 Type of Change

- [x] 🐛 Bug fix

---

## 🧪 How Has This Been Tested?

- [x] Manual testing
- Verified the OTP model now has the expected columns
- Verified \`generate_otp\`, \`is_otp_locked\`, \`get_cooldown_remaining\`, and \`verify_otp\` execute without \`AttributeError\`

---

## 📸 Screenshots (if applicable)

N/A (backend fix)

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes

Only \`app/auth/otp_manager.py\` and \`app/models.py\` were modified. The fix is minimal.