### PR TITLE
Implemented Race Condition

### DIFF
--- a/frontend-web/src/lib/api/client.ts
+++ b/frontend-web/src/lib/api/client.ts
@@ -5,6 +5,22 @@ import { getSession, saveSession } from '../utils/sessionStorage';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:8000/api/v1';
 
+// State variables for token refresh locking mechanism
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (value?: unknown) => void;
+  reject: (reason?: any) => void;
+}> = [];
+
+// Process the queue of failed requests
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) prom.reject(error);
+    else prom.resolve(token);
+  });
+  failedQueue = [];
+};
+
 interface RequestOptions extends RequestInit {
   timeout?: number;
   skipAuth?: boolean; // For public endpoints like login
@@ -89,37 +105,59 @@ export async function apiClient<T>(endpoint: string, options: RequestOptions = {
 
         // Handle 401 - Unauthorized
         if (response.status === 401) {
-          if (!options._isRetry) {
-            try {
-              // Internal refresh fetch to avoid circular dependency
-              const refreshRes = await fetch(`${API_BASE_URL}/auth/refresh`, {
-                method: 'POST',
-                // Include cookies for refresh token
-                credentials: 'include',
-              });
-
-              if (refreshRes.ok) {
-                const data = await refreshRes.json();
-
-                // Update session
-                const session = getSession();
-                if (session) {
-                  session.token = data.access_token;
-                  if (data.refresh_token) {
-                    // Cookie is HTTPOnly
-                  }
-                  // Persist update (keeping existing storage type)
-                  saveSession(session, !!localStorage.getItem('soul_sense_auth_session'));
-                }
-
-                // Retry original request with new token
-                return apiClient(endpoint, { ...options, _isRetry: true });
-              }
-            } catch (err) {
-              console.error('Token refresh failed:', err);
-            }
+          if (options._isRetry) {
+            throw apiError;
           }
-          handleAuthFailure();
+
+          if (isRefreshing) {
+            // Queue the request
+            return new Promise((resolve, reject) => {
+              failedQueue.push({ resolve, reject });
+            }).then(() => {
+              return apiClient(endpoint, { ...options, _isRetry: true });
+            });
+          }
+
+          // Start refreshing
+          isRefreshing = true;
+
+          try {
+            // Internal refresh fetch to avoid circular dependency
+            const refreshRes = await fetch(`${API_BASE_URL}/auth/refresh`, {
+              method: 'POST',
+              // Include cookies for refresh token
+              credentials: 'include',
+            });
+
+            if (refreshRes.ok) {
+              const data = await refreshRes.json();
+
+              // Update session
+              const session = getSession();
+              if (session) {
+                session.token = data.access_token;
+                if (data.refresh_token) {
+                  // Cookie is HTTPOnly
+                }
+                // Persist update (keeping existing storage type)
+                saveSession(session, !!localStorage.getItem('soul_sense_auth_session'));
+              }
+
+              processQueue(null, data.access_token);
+
+              // Retry original request with new token
+              return apiClient(endpoint, { ...options, _isRetry: true });
+            } else {
+              throw new Error('Refresh failed');
+            }
+          } catch (err) {
+            console.error('Token refresh failed:', err);
+            processQueue(err, null);
+            handleAuthFailure();
+            throw apiError;
+          } finally {
+            isRefreshing = false;
+          }
         }
 
         throw apiError;


### PR DESCRIPTION
Closes #860
Fixes #860 

## Changes Implemented
Added state variables at the top of the file:

[isRefreshing](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Boolean flag to track if a refresh is in progress
[failedQueue](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Array to hold promises for queued requests
Added [processQueue](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) function to resolve or reject all queued requests after refresh completes.

Refactored the 401 error handling logic to:

Immediately reject if the request is already a retry ([_isRetry](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is true)
Queue the request if a refresh is already in progress
Perform a single refresh if none is ongoing, then process the queue
Ensure [isRefreshing](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is reset in a finally block
## Key Features
Thread-safe: Only one refresh operation occurs at a time
Queue management: Concurrent 401s are queued and replayed after successful refresh
Error handling: If refresh fails, all queued requests are rejected and logout is triggered
Backward compatible: Maintains existing retry logic and session management
## Validation
✅ TypeScript compilation passes without errors
✅ ESLint checks pass
✅ Logic follows the exact implementation strategy described in the issue
The implementation ensures that when multiple API requests encounter 401s simultaneously, only one POST /auth/refresh call is made, and all subsequent requests are properly queued and retried with the new token. If the refresh fails, all requests fail gracefully and trigger the logout flow.

Closes #860