### PR TITLE
Security: Add session data integrity protection

### DIFF
--- a/app/auth/session_storage.py
+++ b/app/auth/session_storage.py
@@ -7,47 +7,80 @@ Manages persistent session storage for auto-login functionality.
 import os
 import json
 import time
+import hmac
+import hashlib
+import secrets
 from pathlib import Path
 from typing import Optional, Dict, Any
 import logging
 
-# Session file location in app_data directory
-SESSION_FILE = Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) / "app_data" / "session.json"
-SESSION_MAX_AGE_DAYS = 30  # Sessions expire after 30 days
+SESSION_FILE = (
+    Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    / "app_data"
+    / "session.json"
+)
+SECRET_KEY_FILE = (
+    Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    / "app_data"
+    / ".session_key"
+)
+SESSION_MAX_AGE_DAYS = 30
+
+
+def _get_or_create_secret_key() -> bytes:
+    secret = os.environ.get("SOUL_SENSE_SESSION_SECRET")
+    if secret:
+        return secret.encode("utf-8")
+
+    if SECRET_KEY_FILE.exists():
+        try:
+            with open(SECRET_KEY_FILE, "r") as f:
+                return f.read().strip().encode("utf-8")
+        except Exception:
+            pass
+
+    new_key = secrets.token_hex(32)
+    try:
+        SECRET_KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(SECRET_KEY_FILE, "w") as f:
+            f.write(new_key)
+        os.chmod(SECRET_KEY_FILE, 0o600)
+    except Exception as e:
+        logging.error(f"Failed to store session secret key: {e}")
+
+    return new_key.encode("utf-8")
+
+
+def _compute_signature(data: Dict[str, Any], secret: bytes) -> str:
+    payload = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    return hmac.new(secret, payload.encode("utf-8"), hashlib.sha256).hexdigest()
 
 
 def _ensure_session_dir():
-    """Ensure the session directory exists."""
     SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 
 def save_session(username: str, remember_me: bool = False) -> bool:
-    """
-    Save session data to file.
-    
-    Args:
-        username: The logged-in username
-        remember_me: If True, session persists across app restarts
-        
-    Returns:
-        True if session was saved successfully
-    """
     if not remember_me:
-        # Don't save session if remember_me is not checked
         clear_session()
         return True
-    
+
     try:
         _ensure_session_dir()
+        secret = _get_or_create_secret_key()
+
         session_data = {
             "username": username,
             "login_time": time.time(),
-            "expires_at": time.time() + (SESSION_MAX_AGE_DAYS * 24 * 60 * 60)
+            "expires_at": time.time() + (SESSION_MAX_AGE_DAYS * 24 * 60 * 60),
         }
-        
-        with open(SESSION_FILE, 'w') as f:
-            json.dump(session_data, f, indent=2)
-        
+
+        signature = _compute_signature(session_data, secret)
+        signed_session = {"data": session_data, "signature": signature}
+
+        with open(SESSION_FILE, "w") as f:
+            json.dump(signed_session, f, indent=2)
+
         logging.info(f"Session saved for user: {username}")
         return True
     except Exception as e:
@@ -56,24 +89,35 @@ def save_session(username: str, remember_me: bool = False) -> bool:
 
 
 def get_session() -> Optional[Dict[str, Any]]:
-    """
-    Retrieve saved session data.
-    
-    Returns:
-        Session data dict if valid session exists, None otherwise
-    """
     try:
         if not SESSION_FILE.exists():
             return None
-        
-        with open(SESSION_FILE, 'r') as f:
-            session_data = json.load(f)
-        
-        # Validate session structure
+
+        secret = _get_or_create_secret_key()
+
+        with open(SESSION_FILE, "r") as f:
+            signed_session = json.load(f)
+
+        if not all(k in signed_session for k in ["data", "signature"]):
+            clear_session()
+            return None
+
+        session_data = signed_session["data"]
+        stored_signature = signed_session["signature"]
+
         if not all(k in session_data for k in ["username", "login_time", "expires_at"]):
             clear_session()
             return None
-        
+
+        expected_signature = _compute_signature(session_data, secret)
+
+        if not hmac.compare_digest(stored_signature, expected_signature):
+            logging.warning(
+                "Session signature verification failed - possible tampering detected"
+            )
+            clear_session()
+            return None
+
         return session_data
     except Exception as e:
         logging.error(f"Failed to read session: {e}")
@@ -81,31 +125,18 @@ def get_session() -> Optional[Dict[str, Any]]:
 
 
 def is_session_valid() -> bool:
-    """
-    Check if a valid, non-expired session exists.
-    
-    Returns:
-        True if valid session exists
-    """
     session = get_session()
     if not session:
         return False
-    
-    # Check if session has expired
+
     if time.time() > session.get("expires_at", 0):
         clear_session()
         return False
-    
+
     return True
 
 
 def get_saved_username() -> Optional[str]:
-    """
-    Get the username from a valid saved session.
-    
-    Returns:
-        Username if valid session exists, None otherwise
-    """
     if is_session_valid():
         session = get_session()
         return session.get("username") if session else None
@@ -113,12 +144,6 @@ def get_saved_username() -> Optional[str]:
 
 
 def clear_session() -> bool:
-    """
-    Clear saved session data.
-    
-    Returns:
-        True if session was cleared (or didn't exist)
-    """
     try:
         if SESSION_FILE.exists():
             SESSION_FILE.unlink()


### PR DESCRIPTION
Closes #837 
Fixes #837


## Summary
- Add HMAC signature verification to session data storage
- Session data is now signed using a secret key stored outside the session file
- Secret key can be provided via `SOUL_SENSE_SESSION_SECRET` environment variable or auto-generated and stored in `.session_key`
- Signature verification prevents tampering with session data

## Security Impact
This prevents local attackers from modifying `app_data/session.json` to impersonate other users, as any tampering will be detected and the session will be rejected.

Fixes #837