### PR TITLE
Fixed Arrow Key Conflict

### DIFF
--- a/frontend-web/src/components/exam/exam-navigation.tsx
+++ b/frontend-web/src/components/exam/exam-navigation.tsx
@@ -28,7 +28,16 @@ export const ExamNavigation: React.FC<ExamNavigationProps> = ({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (['INPUT', 'TEXTAREA'].includes((e.target as HTMLElement).tagName)) return;
+      const activeElement = document.activeElement;
+      const isInputFocused =
+        activeElement &&
+        (activeElement.tagName === "INPUT" ||
+        activeElement.tagName === "TEXTAREA" ||
+        activeElement.tagName === "SELECT" ||
+        activeElement.getAttribute("role") === "radio");
+      if (isInputFocused) {
+        return; // Abort global navigation, let the browser handle standard UI traversing.
+      }
 
       if (e.key === 'ArrowLeft' && !isFirst) {
         previousQuestion();


### PR DESCRIPTION
Closes #875
Fixes #875


## Summary

The fix has been successfully implemented. The [handleKeyDown](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) event listener in [exam-navigation.tsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now properly checks [document.activeElement](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and ignores arrow key presses when interactive elements (inputs, textareas, selects, or elements with role="radio") are focused. This allows native browser behavior for form navigation while preserving global exam navigation when no such elements are active.

The code compiles successfully, and no new linting errors were introduced. The change aligns with the technical strategy outlined in the issue, ensuring WCAG compliance and a better user experience. You can now test the functionality as described in the acceptance criteria.


Closes #875