### PR TITLE
Client redirect 876

### DIFF
--- a/frontend-web/src/app/(app)/layout.tsx
+++ b/frontend-web/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { Sidebar, Header } from '@/components/app';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
+  // Authentication checks are handled by Edge middleware; this hook is used only for UI state
   const { isAuthenticated, isLoading } = useAuth();
 
   return (

--- a/frontend-web/src/components/exam/exam-navigation.tsx
+++ b/frontend-web/src/components/exam/exam-navigation.tsx
@@ -27,6 +27,8 @@ export const ExamNavigation: React.FC<ExamNavigationProps> = ({
   const isLast = getIsLastQuestion();
 
   useEffect(() => {
+    // Handle keyboard navigation for exam questions, but ignore when form elements are focused
+    // to allow native browser behavior for radio buttons, inputs, etc. (fixes #875)
     const handleKeyDown = (e: KeyboardEvent) => {
       const activeElement = document.activeElement;
       const isInputFocused =


### PR DESCRIPTION
Closes #876
Fixes #876


## Summary

[exam-navigation.tsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added a comment above the [handleKeyDown](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) function explaining that it handles keyboard navigation for exam questions but ignores form elements to allow native browser behavior, referencing issue #875.

[layout.tsx](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added a comment clarifying that authentication checks are handled by Edge middleware, and the [useAuth](vscode-file://vscode-app/c:/Users/Gupta/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) hook is used only for UI conditional rendering.

The comments help document the architectural decisions and prevent future regressions. The code still passes compilation, and the linting errors shown are pre-existing issues unrelated to these changes










Closes   #876.