### PR TITLE
feat: ETag Headers

### DIFF
--- a/backend/fastapi/api/main.py
+++ b/backend/fastapi/api/main.py
@@ -224,6 +224,12 @@ def create_app() -> FastAPI:
     from .middleware.security import SecurityHeadersMiddleware
     app.add_middleware(SecurityHeadersMiddleware)
 
+    # ETag Middleware for HTTP caching optimization
+    # Adds ETag headers to static resources (questions, prompts, translations)
+    # Returns 304 Not Modified when content hasn't changed, saving bandwidth
+    from .middleware.etag_middleware import ETagMiddleware
+    app.add_middleware(ETagMiddleware)
+
     # CORS middleware
     # In debug mode, allow all origins for easier development
     if settings.debug:
@@ -239,7 +245,7 @@ def create_app() -> FastAPI:
         allow_credentials=allow_credentials,
         allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
         allow_headers=["Content-Type", "Authorization", "Accept", "Origin", "X-Requested-With"],
-        expose_headers=["X-API-Version", "X-Request-ID", "X-Process-Time"],  # Expose request ID for frontend tracing
+        expose_headers=["X-API-Version", "X-Request-ID", "X-Process-Time", "ETag"],  # Expose request ID for frontend tracing
         max_age=3600,  # Cache preflight requests for 1 hour
     )
     

--- a/backend/fastapi/api/middleware/etag_middleware.py
+++ b/backend/fastapi/api/middleware/etag_middleware.py
@@ -1,0 +1,335 @@
+"""
+ETag Middleware for FastAPI
+
+Provides HTTP ETag header support for caching static resources.
+- Computes MD5 hash of JSON response bodies
+- Returns 304 Not Modified when content hasn't changed
+- Skips ETag computation for streaming responses
+- Reduces bandwidth for repeated requests to static endpoints
+"""
+
+import hashlib
+import json
+import logging
+from typing import Callable, Optional, Set
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response, StreamingResponse
+
+logger = logging.getLogger("api.etag")
+
+
+class ETagMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to add ETag headers for HTTP caching optimization.
+    
+    Features:
+    - Computes MD5 hash of response bodies for ETag generation
+    - Compares against If-None-Match header from client
+    - Returns 304 Not Modified with empty body when content unchanged
+    - Skips ETag computation for streaming responses (to avoid blocking)
+    - Adds ETag header to all applicable GET responses
+    
+    This significantly reduces bandwidth for static resources like:
+    - Question geometries (/api/v1/questions)
+    - System prompts
+    - Language dictionaries
+    """
+    
+    # Path patterns that should have ETag caching enabled
+    # These are typically static resources that don't change frequently
+    ETAG_ENABLED_PATHS: Set[str] = {
+        "/api/v1/questions",
+        "/api/v1/questions/categories",
+    }
+    
+    # Path prefixes that should have ETag caching enabled
+    ETAG_ENABLED_PREFIXES: Set[str] = {
+        "/api/v1/questions/",
+    }
+    
+    def __init__(self, app: Callable, enabled_paths: Optional[Set[str]] = None, 
+                 enabled_prefixes: Optional[Set[str]] = None):
+        """
+        Initialize ETag middleware.
+        
+        Args:
+            app: The ASGI application
+            enabled_paths: Set of exact paths to enable ETag for (optional, extends defaults)
+            enabled_prefixes: Set of path prefixes to enable ETag for (optional, extends defaults)
+        """
+        super().__init__(app)
+        if enabled_paths:
+            self.ETAG_ENABLED_PATHS = self.ETAG_ENABLED_PATHS | enabled_paths
+        if enabled_prefixes:
+            self.ETAG_ENABLED_PREFIXES = self.ETAG_ENABLED_PREFIXES | enabled_prefixes
+    
+    def _should_process_etag(self, request: Request) -> bool:
+        """
+        Check if ETag processing should be applied to this request.
+        
+        Only applies to GET requests for enabled paths.
+        """
+        # Only process GET requests
+        if request.method != "GET":
+            return False
+        
+        path = request.url.path
+        
+        # Check exact path match
+        if path in self.ETAG_ENABLED_PATHS:
+            return True
+        
+        # Check prefix match
+        for prefix in self.ETAG_ENABLED_PREFIXES:
+            if path.startswith(prefix):
+                return True
+        
+        return False
+    
+    def _compute_etag(self, body: bytes) -> str:
+        """
+        Compute ETag (MD5 hash) for response body.
+        
+        Args:
+            body: Raw response body bytes
+            
+        Returns:
+            MD5 hash string wrapped in quotes per HTTP spec
+        """
+        hash_value = hashlib.md5(body).hexdigest()
+        # ETags should be wrapped in quotes per HTTP spec
+        return f'"{hash_value}"'
+    
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        """
+        Process request with ETag support.
+        
+        1. Check if request should have ETag processing
+        2. Execute request and get response
+        3. If streaming response, return as-is (skip ETag)
+        4. Capture response body and compute ETag hash
+        5. Compare against If-None-Match header
+        6. Return 304 if match, otherwise return response with ETag header
+        """
+        # Check if we should process ETag for this request
+        should_process = self._should_process_etag(request)
+        
+        # Process the request
+        response = await call_next(request)
+        
+        # Skip ETag processing if not applicable
+        if not should_process:
+            return response
+        
+        # Skip ETag for streaming responses (can't hash without consuming stream)
+        if isinstance(response, StreamingResponse):
+            logger.debug(f"Skipping ETag for streaming response: {request.url.path}")
+            return response
+        
+        # Only process successful responses (200 OK)
+        if response.status_code != 200:
+            return response
+        
+        try:
+            # Consume the body iterator and rebuild the response
+            body_chunks = []
+            async for chunk in response.body_iterator:
+                if isinstance(chunk, str):
+                    body_chunks.append(chunk.encode('utf-8'))
+                else:
+                    body_chunks.append(chunk)
+            
+            body = b''.join(body_chunks)
+            
+            if not body:
+                return response
+            
+            # Compute ETag
+            etag = self._compute_etag(body)
+            
+            # Check If-None-Match header from client
+            if_none_match = request.headers.get("if-none-match")
+            
+            if if_none_match and if_none_match == etag:
+                # Content hasn't changed - return 304 Not Modified
+                logger.debug(f"ETag match for {request.url.path}, returning 304")
+                return Response(
+                    status_code=304,
+                    headers={
+                        "ETag": etag,
+                        "Cache-Control": "private, must-revalidate"
+                    }
+                )
+            
+            # Content changed or no If-None-Match header
+            # We need to reconstruct the response since we consumed the body_iterator
+            new_response = Response(
+                content=body,
+                status_code=response.status_code,
+                headers=dict(response.headers),
+                media_type=response.media_type,
+                background=response.background if hasattr(response, 'background') else None
+            )
+            new_response.headers["ETag"] = etag
+            new_response.headers["Cache-Control"] = "private, must-revalidate"
+            
+            return new_response
+            
+        except Exception as e:
+            # If ETag processing fails, log error and return original response
+            logger.warning(f"ETag processing failed for {request.url.path}: {e}")
+            return response
+
+
+class ConditionalETagMiddleware(BaseHTTPMiddleware):
+    """
+    Alternative ETag middleware that operates on all JSON GET responses
+    unless explicitly excluded. Use with caution on dynamic endpoints.
+    
+    This is useful when you want ETag support broadly but need to 
+    explicitly mark dynamic endpoints that shouldn't be cached.
+    """
+    
+    # Paths that should NEVER have ETag (dynamic/user-specific data)
+    ETAG_EXCLUDED_PATHS: Set[str] = {
+        "/api/v1/auth/me",
+        "/api/v1/users/me",
+    }
+    
+    # Path prefixes that should NEVER have ETag
+    ETAG_EXCLUDED_PREFIXES: Set[str] = {
+        "/api/v1/auth/",
+        "/api/v1/analytics/",
+        "/api/v1/journal/",
+        "/api/v1/assessments/",
+        "/api/v1/exams/",
+        "/api/v1/profiles/medical",
+    }
+    
+    def _should_exclude(self, request: Request) -> bool:
+        """Check if this path should be excluded from ETag processing."""
+        path = request.url.path
+        
+        # Check exact path exclusion
+        if path in self.ETAG_EXCLUDED_PATHS:
+            return True
+        
+        # Check prefix exclusion
+        for prefix in self.ETAG_EXCLUDED_PREFIXES:
+            if path.startswith(prefix):
+                return True
+        
+        return False
+    
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        """Process request with conditional ETag support."""
+        response = await call_next(request)
+        
+        # Only process successful GET requests
+        if request.method != "GET":
+            return response
+        
+        if response.status_code != 200:
+            return response
+        
+        # Skip excluded paths
+        if self._should_exclude(request):
+            return response
+        
+        # Skip streaming responses
+        if isinstance(response, StreamingResponse):
+            return response
+        
+        try:
+            # Consume the body iterator and rebuild the response
+            body_chunks = []
+            async for chunk in response.body_iterator:
+                if isinstance(chunk, str):
+                    body_chunks.append(chunk.encode('utf-8'))
+                else:
+                    body_chunks.append(chunk)
+            
+            body = b''.join(body_chunks)
+            
+            if not body:
+                return response
+            
+            # Compute ETag
+            etag = hashlib.md5(body).hexdigest()
+            etag_header = f'"{etag}"'
+            
+            # Check If-None-Match
+            if_none_match = request.headers.get("if-none-match")
+            
+            if if_none_match and if_none_match == etag_header:
+                return Response(
+                    status_code=304,
+                    headers={
+                        "ETag": etag_header,
+                        "Cache-Control": "private, must-revalidate"
+                    }
+                )
+            
+            # Return response with ETag
+            new_response = Response(
+                content=body,
+                status_code=response.status_code,
+                headers=dict(response.headers),
+                media_type=response.media_type,
+                background=response.background if hasattr(response, 'background') else None
+            )
+            new_response.headers["ETag"] = etag_header
+            new_response.headers["Cache-Control"] = "private, must-revalidate"
+            
+            return new_response
+            
+        except Exception as e:
+            logger.warning(f"Conditional ETag processing failed: {e}")
+            return response
+
+
+def create_etag_middleware(enabled_paths: Optional[Set[str]] = None,
+                           enabled_prefixes: Optional[Set[str]] = None) -> type:
+    """
+    Factory function to create ETag middleware with custom configuration.
+    
+    Usage:
+        from api.middleware.etag_middleware import create_etag_middleware
+        
+        ETagMiddleware = create_etag_middleware(
+            enabled_paths={"/api/v1/custom/resource"},
+            enabled_prefixes={"/api/v1/static/"}
+        )
+        app.add_middleware(ETagMiddleware)
+    
+    Args:
+        enabled_paths: Additional exact paths to enable ETag for
+        enabled_prefixes: Additional path prefixes to enable ETag for
+        
+    Returns:
+        Configured ETagMiddleware class
+    """
+    class ConfiguredETagMiddleware(ETagMiddleware):
+        def __init__(self, app: Callable):
+            super().__init__(app, enabled_paths, enabled_prefixes)
+    
+    return ConfiguredETagMiddleware
+
+
+def generate_etag_for_data(data: dict) -> str:
+    """
+    Generate an ETag for a dictionary of data.
+    
+    Utility function to generate ETags manually in route handlers if needed.
+    
+    Args:
+        data: Dictionary to generate ETag for
+        
+    Returns:
+        ETag string (MD5 hash wrapped in quotes)
+    """
+    body = json.dumps(data, sort_keys=True, ensure_ascii=False).encode('utf-8')
+    hash_value = hashlib.md5(body).hexdigest()
+    return f'"{hash_value}"'

--- a/backend/fastapi/tests/unit/test_etag_middleware.py
+++ b/backend/fastapi/tests/unit/test_etag_middleware.py
@@ -1,0 +1,316 @@
+"""
+Unit tests for ETag Middleware
+
+Tests:
+- ETag header is added to configured paths
+- 304 Not Modified returned when If-None-Match matches
+- ETag skipped for streaming responses
+- ETag skipped for non-GET requests
+- ETag skipped for non-configured paths
+"""
+
+import pytest
+import hashlib
+import json
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse, StreamingResponse
+from starlette.testclient import TestClient
+
+import sys
+from pathlib import Path
+
+# Add backend to path
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from backend.fastapi.api.middleware.etag_middleware import (
+    ETagMiddleware,
+    ConditionalETagMiddleware,
+    create_etag_middleware
+)
+
+
+# Test fixtures
+@pytest.fixture
+def sample_app():
+    """Create a test FastAPI app with ETag middleware."""
+    app = FastAPI()
+    
+    @app.get("/api/v1/questions")
+    async def get_questions():
+        return {"questions": [{"id": 1, "text": "Test question"}]}
+    
+    @app.get("/api/v1/questions/categories")
+    async def get_categories():
+        return {"categories": [{"id": 1, "name": "Test"}]}
+    
+    @app.get("/api/v1/questions/{question_id}")
+    async def get_question(question_id: int):
+        return {"id": question_id, "text": "Test question"}
+    
+    @app.get("/api/v1/users/me")
+    async def get_user():
+        return {"id": 1, "name": "Test User"}
+    
+    @app.post("/api/v1/questions")
+    async def create_question():
+        return {"id": 2, "text": "New question"}
+    
+    @app.get("/api/v1/stream")
+    async def stream_data():
+        async def generate():
+            yield b"data: chunk1\n\n"
+            yield b"data: chunk2\n\n"
+        return StreamingResponse(generate(), media_type="text/event-stream")
+    
+    # Add ETag middleware
+    app.add_middleware(ETagMiddleware)
+    
+    return app
+
+
+@pytest.fixture
+def client(sample_app):
+    """Create a test client."""
+    return TestClient(sample_app)
+
+
+# Test cases
+class TestETagMiddleware:
+    """Test suite for ETag middleware."""
+    
+    def test_etag_header_added_to_questions(self, client):
+        """ETag header should be added to /api/v1/questions response."""
+        response = client.get("/api/v1/questions")
+        
+        assert response.status_code == 200
+        assert "etag" in response.headers
+        # ETag should be wrapped in quotes
+        etag = response.headers["etag"]
+        assert etag.startswith('"') and etag.endswith('"')
+    
+    def test_etag_header_added_to_categories(self, client):
+        """ETag header should be added to /api/v1/questions/categories."""
+        response = client.get("/api/v1/questions/categories")
+        
+        assert response.status_code == 200
+        assert "etag" in response.headers
+    
+    def test_etag_header_added_to_specific_question(self, client):
+        """ETag header should be added to /api/v1/questions/{id}."""
+        response = client.get("/api/v1/questions/123")
+        
+        assert response.status_code == 200
+        assert "etag" in response.headers
+    
+    def test_etag_not_added_to_unconfigured_path(self, client):
+        """ETag should not be added to paths not in ETAG_ENABLED_PATHS."""
+        response = client.get("/api/v1/users/me")
+        
+        assert response.status_code == 200
+        # ETag should not be present for unconfigured paths
+        assert "etag" not in response.headers
+    
+    def test_etag_not_added_to_post_request(self, client):
+        """ETag should not be added to POST requests."""
+        response = client.post("/api/v1/questions")
+        
+        assert response.status_code == 200
+        # ETag should not be present for POST requests
+        assert "etag" not in response.headers
+    
+    def test_304_returned_when_etag_matches(self, client):
+        """304 Not Modified should be returned when If-None-Match matches ETag."""
+        # First request - get the ETag
+        response1 = client.get("/api/v1/questions")
+        assert response1.status_code == 200
+        etag = response1.headers["etag"]
+        
+        # Second request with If-None-Match header
+        response2 = client.get(
+            "/api/v1/questions",
+            headers={"If-None-Match": etag}
+        )
+        
+        # Should return 304 Not Modified
+        assert response2.status_code == 304
+        assert response2.headers["etag"] == etag
+        # Body should be empty
+        assert response2.content == b""
+    
+    def test_200_returned_when_etag_mismatches(self, client):
+        """200 OK should be returned when If-None-Match doesn't match."""
+        # Request with wrong ETag
+        response = client.get(
+            "/api/v1/questions",
+            headers={"If-None-Match": '"wrongetag"'}
+        )
+        
+        # Should return 200 with full response
+        assert response.status_code == 200
+        assert "etag" in response.headers
+        assert response.json() == {"questions": [{"id": 1, "text": "Test question"}]}
+    
+    def test_etag_not_added_to_streaming_response(self, client):
+        """ETag should not be added to streaming responses."""
+        response = client.get("/api/v1/stream")
+        
+        assert response.status_code == 200
+        # ETag should not be present for streaming responses
+        assert "etag" not in response.headers
+
+
+class TestConditionalETagMiddleware:
+    """Test suite for ConditionalETagMiddleware."""
+    
+    @pytest.fixture
+    def conditional_app(self):
+        """Create app with conditional ETag middleware."""
+        app = FastAPI()
+        
+        @app.get("/api/v1/questions")
+        async def get_questions():
+            return {"questions": [{"id": 1, "text": "Test"}]}
+        
+        @app.get("/api/v1/auth/login")
+        async def login():
+            return {"token": "test"}
+        
+        @app.get("/api/v1/analytics/summary")
+        async def analytics():
+            return {"total": 100}
+        
+        # Add conditional ETag middleware
+        app.add_middleware(ConditionalETagMiddleware)
+        
+        return app
+    
+    @pytest.fixture
+    def conditional_client(self, conditional_app):
+        """Create test client for conditional app."""
+        return TestClient(conditional_app)
+    
+    def test_etag_added_to_non_excluded_path(self, conditional_client):
+        """ETag should be added to paths not in exclusion list."""
+        response = conditional_client.get("/api/v1/questions")
+        
+        assert response.status_code == 200
+        assert "etag" in response.headers
+    
+    def test_etag_not_added_to_auth_path(self, conditional_client):
+        """ETag should not be added to auth paths."""
+        response = conditional_client.get("/api/v1/auth/login")
+        
+        assert response.status_code == 200
+        assert "etag" not in response.headers
+    
+    def test_etag_not_added_to_analytics_path(self, conditional_client):
+        """ETag should not be added to analytics paths."""
+        response = conditional_client.get("/api/v1/analytics/summary")
+        
+        assert response.status_code == 200
+        assert "etag" not in response.headers
+
+
+class TestETagFactory:
+    """Test suite for ETag middleware factory."""
+    
+    def test_create_etag_middleware_with_custom_paths(self):
+        """Factory should create middleware with custom enabled paths."""
+        CustomETagMiddleware = create_etag_middleware(
+            enabled_paths={"/custom/path"},
+            enabled_prefixes={"/custom/"}
+        )
+        
+        app = FastAPI()
+        
+        @app.get("/custom/path")
+        async def custom_path():
+            return {"data": "test"}
+        
+        @app.get("/custom/resource")
+        async def custom_resource():
+            return {"data": "test"}
+        
+        app.add_middleware(CustomETagMiddleware)
+        
+        client = TestClient(app)
+        
+        # Both paths should have ETag
+        response1 = client.get("/custom/path")
+        assert "etag" in response1.headers
+        
+        response2 = client.get("/custom/resource")
+        assert "etag" in response2.headers
+
+
+class TestETagComputation:
+    """Test ETag computation logic."""
+    
+    def test_etag_is_md5_hash(self):
+        """ETag should be MD5 hash wrapped in quotes."""
+        from backend.fastapi.api.middleware.etag_middleware import create_etag_middleware
+        
+        # Create middleware with /test path enabled
+        CustomETagMiddleware = create_etag_middleware(
+            enabled_paths={"/test"}
+        )
+        
+        app = FastAPI()
+        
+        @app.get("/test")
+        async def test_endpoint():
+            return {"test": "data"}
+        
+        app.add_middleware(CustomETagMiddleware)
+        client = TestClient(app)
+        
+        response = client.get("/test")
+        etag = response.headers.get("etag", "")
+        
+        # ETag should be wrapped in quotes
+        assert etag.startswith('"') and etag.endswith('"')
+        
+        # Inner value should be valid MD5 (32 hex characters)
+        hash_value = etag[1:-1]  # Remove quotes
+        assert len(hash_value) == 32
+        assert all(c in '0123456789abcdef' for c in hash_value)
+    
+    def test_same_content_same_etag(self):
+        """Same content should produce same ETag."""
+        app = FastAPI()
+        
+        @app.get("/api/v1/questions")
+        async def questions():
+            return {"data": "static"}
+        
+        app.add_middleware(ETagMiddleware)
+        client = TestClient(app)
+        
+        response1 = client.get("/api/v1/questions")
+        response2 = client.get("/api/v1/questions")
+        
+        assert response1.headers["etag"] == response2.headers["etag"]
+    
+    def test_different_content_different_etag(self):
+        """Different content should produce different ETag."""
+        counter = {"value": 0}
+        
+        app = FastAPI()
+        
+        @app.get("/api/v1/questions")
+        async def questions():
+            counter["value"] += 1
+            return {"data": counter["value"]}
+        
+        app.add_middleware(ETagMiddleware)
+        client = TestClient(app)
+        
+        response1 = client.get("/api/v1/questions")
+        response2 = client.get("/api/v1/questions")
+        
+        assert response1.headers["etag"] != response2.headers["etag"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #958
Closes #958


## 📌 Description
This PR implements HTTP ETag (Entity Tag) header support for the FastAPI backend to optimize bandwidth usage for static resources. When clients request resources they've already cached, the server returns `304 Not Modified` with an empty body instead of resending the entire payload.

Fixes: #958 

---

## Problem Statement

Currently, the Next.js frontend dynamically downloads static platform resources (question geometries, system prompts, language dictionaries) fresh on every page load or tab refresh. This consumes significant bandwidth (~250KB per request) for identical datasets, even when the data hasn't changed.

## Solution

Implemented a FastAPI middleware that:
1. Computes MD5 hash of JSON response bodies to generate ETags
2. Compares against the `If-None-Match` HTTP header sent by browsers
3. Returns `304 Not Modified` with empty body when content matches
4. Skips ETag computation for streaming responses to avoid blocking


## 🔧 Type of Change
Please mark the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [ ] 🎨 UI / Styling change
- [ ] 🚀 Other (Security Hardening): Prevents unauthorized local domains from hitting production backends.

---

## 🧪 How Has This Been Tested?
Describe the tests you ran to verify your changes.

- [ ] Manual testing
- [x] Automated tests 

```bash
python -m pytest backend/fastapi/tests/unit/test_etag_middleware.py -v
```

All 15 tests pass, covering:
- ETag header generation
- 304 Not Modified responses
- Streaming response bypass
- Non-configured path exclusion
- POST request exclusion
---


## 📸 Screenshots (if applicable)
N/A

---

## ✅ Checklist
Please confirm the following:

- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---