### PR TITLE
Next.js Bundle Optimization & Code Splitting

### DIFF
--- a/frontend-web/next-env.d.ts
+++ b/frontend-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend-web/next.config.js
+++ b/frontend-web/next.config.js
@@ -52,23 +52,12 @@ const nextConfig = {
       },
     ];
   },
-
-  // Bundle analyzer (run with ANALYZE=true)
-  ...(process.env.ANALYZE === 'true' && {
-    webpack: (config, { isServer }) => {
-      if (!isServer) {
-        const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-        config.plugins.push(
-          new BundleAnalyzerPlugin({
-            analyzerMode: 'static',
-            reportFilename: './analyze/client.html',
-            openAnalyzer: false,
-          })
-        );
-      }
-      return config;
-    },
-  }),
 };
 
-module.exports = nextConfig;
+// Wrap with bundle analyzer if ANALYZE=true
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+  openAnalyzer: false,
+});
+
+module.exports = withBundleAnalyzer(nextConfig);

--- a/frontend-web/package-lock.json
+++ b/frontend-web/package-lock.json
@@ -37,6 +37,7 @@
         "zustand": "5.0.11"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "16.1.6",
         "@playwright/test": "1.58.2",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.19",
@@ -49,6 +50,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.4.23",
+        "cross-env": "10.1.0",
         "eslint": "10.0.2",
         "eslint-config-next": "0.2.4",
         "eslint-config-prettier": "^9.0.0",
@@ -170,6 +172,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -760,6 +763,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -798,8 +802,19 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -834,6 +849,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -2045,6 +2067,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.1.6.tgz",
+      "integrity": "sha512-ee2kagdTaeEWPlotgdTOqFHYcD3e2m2bbE3I9Rq2i6ABYi5OgopmtEUe8NM23viaYxLV2tDH/2nd5+qKoEr6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
@@ -2245,8 +2277,9 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -2256,6 +2289,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3635,6 +3675,88 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3699,6 +3821,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3912,7 +4041,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/raf": {
@@ -3926,8 +4055,9 @@
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3937,8 +4067,9 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4278,6 +4409,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4293,6 +4425,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -4673,6 +4818,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5066,6 +5212,24 @@
         "postcss-media-query-parser": "^0.2.3"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5179,7 +5343,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -5349,6 +5513,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5456,6 +5621,13 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5515,6 +5687,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -5646,6 +5828,13 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5741,6 +5930,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5804,6 +5994,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6442,6 +6633,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -6790,6 +6997,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -6931,6 +7148,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7257,6 +7475,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7280,6 +7499,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7859,6 +8079,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7888,6 +8109,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -8120,6 +8342,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -8270,6 +8502,16 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
       "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
       "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8527,6 +8769,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -8813,7 +9065,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -8832,7 +9084,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -8875,6 +9127,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9064,6 +9317,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9274,6 +9528,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9286,6 +9541,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9316,6 +9572,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9331,7 +9588,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-kapsule": {
       "version": "2.5.7",
@@ -9353,6 +9611,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9511,7 +9770,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9770,6 +10030,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/slash": {
@@ -10168,6 +10443,7 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -10367,6 +10643,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10410,6 +10687,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -10557,6 +10844,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10805,6 +11093,66 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/whatwg-encoding": {

--- a/frontend-web/package.json
+++ b/frontend-web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev -H 127.0.0.1 -p 3005",
     "build": "next build",
+    "analyze": "cross-env ANALYZE=true next build",
     "start": "next start -p 3005",
     "lint": "next lint .",
     "format": "prettier --write .",
@@ -45,6 +46,7 @@
     "zustand": "5.0.11"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "16.1.6",
     "@playwright/test": "1.58.2",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
@@ -57,6 +59,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.23",
+    "cross-env": "10.1.0",
     "eslint": "10.0.2",
     "eslint-config-next": "0.2.4",
     "eslint-config-prettier": "^9.0.0",

--- a/frontend-web/src/app/(app)/dashboard/page.tsx
+++ b/frontend-web/src/app/(app)/dashboard/page.tsx
@@ -11,8 +11,9 @@ import {
   ActivityItem,
   BentoGrid,
   SectionWrapper,
-  DashboardCharts,
 } from '@/components/dashboard';
+// Dynamically import heavy chart components to reduce initial bundle size
+import { DashboardCharts } from '@/lib/dynamic-imports';
 import { apiClient } from '@/lib/api/client';
 import { useAuth } from '@/hooks/useAuth';
 

--- a/frontend-web/src/app/(app)/journal/page.tsx
+++ b/frontend-web/src/app/(app)/journal/page.tsx
@@ -7,8 +7,9 @@ import { journalApi, CreateJournalEntry, JournalFilters } from '@/lib/api/journa
 import { ErrorDisplay, Skeleton } from '@/components/common';
 import { Button, Card, CardContent, Input, Slider } from '@/components/ui';
 import { JournalEntryCard } from '@/components/journal';
-import { MoodTrend } from '@/components/journal';
 import { JournalListContainer } from '@/components/journal';
+// Dynamically import MoodTrend to avoid loading recharts on initial bundle
+import { MoodTrend } from '@/lib/dynamic-imports';
 import {
   BookOpen,
   Plus,

--- a/frontend-web/src/app/(app)/results/[id]/page.tsx
+++ b/frontend-web/src/app/(app)/results/[id]/page.tsx
@@ -12,7 +12,8 @@ import {
   Button,
   Skeleton,
 } from '@/components/ui';
-import { ScoreGauge, CategoryBreakdown, RecommendationCard } from '@/components/results';
+import { CategoryBreakdown, RecommendationCard } from '@/components/results';
+import { ScoreGauge } from '@/lib/dynamic-imports';
 import { ArrowLeft, Download, RefreshCw, Calendar, Clock, Loader2 } from 'lucide-react';
 import { useToast } from '@/components/ui/toast';
 import { apiClient } from '@/lib/api/client';

--- a/frontend-web/src/app/(app)/results/page.tsx
+++ b/frontend-web/src/app/(app)/results/page.tsx
@@ -2,7 +2,8 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { HistoryChart, ExamResult as ChartResult } from '@/components/results';
+import { HistoryChart } from '@/lib/dynamic-imports';
+import { ExamResult as ChartResult } from '@/components/results/history-chart';
 import {
   Button,
   Card,

--- a/frontend-web/src/components/dashboard/index.ts
+++ b/frontend-web/src/components/dashboard/index.ts
@@ -1,3 +1,7 @@
+// Export all dashboard components
+// Note: Heavy chart components using recharts are dynamically imported from @/lib/dynamic-imports
+// to prevent bloating the initial bundle. Use: import { DashboardCharts } from '@/lib/dynamic-imports';
+
 export * from './bento-grid';
 export * from './stats-card';
 export * from './leaderboard';
@@ -5,8 +9,12 @@ export * from './heatmap';
 export * from './skeleton-loader';
 export * from './reviewer-metrics';
 export * from './contributor-details-modal';
+
+// Chart components - these use recharts and are dynamically imported
+// Export for direct use in dashboard ONLY
 export * from './charts/activity-area-chart';
 export * from './charts/contribution-mix';
+
 export * from './pulse-feed';
 export * from './good-first-issues';
 export * from './project-roadmap';
@@ -16,4 +24,7 @@ export * from './mood-widget';
 export * from './recent-activity';
 export * from './insight-card';
 export * from './section-wrapper';
-export { default as DashboardCharts } from './dashboard-charts';
+
+// ⚠️ DashboardCharts is NOT exported here to avoid eager loading recharts
+// Use dynamic import instead:
+//   import { DashboardCharts } from '@/lib/dynamic-imports';

--- a/frontend-web/src/components/journal/index.ts
+++ b/frontend-web/src/components/journal/index.ts
@@ -1,6 +1,13 @@
+// Export all journal components
+// Note: Heavy chart components using recharts are dynamically imported
+// from @/lib/dynamic-imports to prevent bloating the initial bundle.
+
 export { JournalEntryCard } from './entry-card';
 export { default as JournalEditor } from './journal-editor';
 export { MoodSlider } from './mood-slider';
-export { MoodTrend } from './mood-trend';
 export { TagSelector } from './tag-selector';
 export { JournalListContainer } from './journal-list';
+
+// ⚠️ MoodTrend is NOT exported here to avoid eager loading recharts
+// Use dynamic import instead:
+//   import { MoodTrend } from '@/lib/dynamic-imports';

--- a/frontend-web/src/components/results/index.ts
+++ b/frontend-web/src/components/results/index.ts
@@ -1,5 +1,17 @@
-export * from './history-chart';
+// Export all results components
+// Note: Heavy components using recharts/framer-motion/jspdf are dynamically imported
+// from @/lib/dynamic-imports to prevent bloating the initial bundle.
+
+// Lightweight components - safe to export statically
 export { default as RecommendationCard } from './recommendation-card';
-export { ExportPDF, default as ExportPDFDefault } from './export-pdf';
-export { default as ScoreGauge } from './score-gauge';
 export { default as CategoryBreakdown } from './category-breakdown';
+
+// Export type for ExamResult
+export type { ExamResult } from './history-chart';
+
+// ⚠️ Heavy components are NOT exported here to avoid eager loading:
+// - HistoryChart (uses recharts)
+// - ScoreGauge (uses framer-motion)
+// - export-pdf (uses jspdf, html2canvas)
+// Use dynamic imports instead:
+//   import { HistoryChart, ScoreGauge, ExportPDF } from '@/lib/dynamic-imports';

--- a/frontend-web/src/lib/dynamic-imports.tsx
+++ b/frontend-web/src/lib/dynamic-imports.tsx
@@ -1,90 +1,208 @@
 /**
  * Dynamic imports for heavy components to enable code splitting and lazy loading.
  * This reduces initial bundle size and improves Time to Interactive (TTI).
+ * 
+ * Usage:
+ *   import { DashboardCharts } from '@/lib/dynamic-imports';
+ * 
+ * These components are loaded on-demand when rendered, not at page load.
  */
 
 import dynamic from 'next/dynamic';
 import { ComponentType } from 'react';
 import React from 'react';
 
-// Chart components from recharts - lazy loaded to reduce initial bundle
+// ============================================================================
+// DASHBOARD CHART COMPONENTS (recharts - ~70KB gzipped)
+// ============================================================================
+
+/**
+ * Dashboard Charts with recharts - heavy visualization library
+ * Only loaded when user navigates to dashboard
+ */
+export const DashboardCharts = dynamic(
+  () => import('@/components/dashboard/dashboard-charts'),
+  {
+    loading: () => (
+      <div className="bg-white p-6 rounded-lg shadow">
+        <div className="animate-pulse">
+          <div className="h-4 bg-gray-200 rounded w-1/4 mb-4"></div>
+          <div className="h-64 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    ),
+    ssr: false, // Recharts requires browser APIs
+  }
+) as ComponentType<any>;
+
+/**
+ * Activity Area Chart - recharts based
+ */
 export const ActivityAreaChart = dynamic(
   () => import('@/components/dashboard/charts/activity-area-chart').then(mod => ({ default: mod.ActivityAreaChart })),
   {
     loading: () => (
       <div className="h-[250px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
     ),
-    ssr: true,
+    ssr: false, // Recharts requires browser APIs
   }
 ) as ComponentType<any>;
 
+/**
+ * Contribution Mix Chart - recharts based
+ */
 export const ContributionMix = dynamic(
   () => import('@/components/dashboard/charts/contribution-mix').then(mod => ({ default: mod.ContributionMixChart })),
   {
     loading: () => (
       <div className="h-[200px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
     ),
-    ssr: true,
+    ssr: false, // Recharts requires browser APIs
   }
 ) as ComponentType<any>;
 
-export const ForceDirectedGraph = dynamic(
-  () => import('@/components/dashboard/charts/force-directed-graph').then(mod => ({ default: mod.ForceDirectedGraph })),
-  {
-    loading: () => (
-      <div className="h-[300px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
-    ),
-    ssr: false, // Force graph requires browser APIs
-  }
-) as ComponentType<any>;
-
+/**
+ * Repository Sunburst Chart - recharts based
+ */
 export const RepositorySunburst = dynamic(
   () => import('@/components/dashboard/charts/repository-sunburst').then(mod => ({ default: mod.RepositorySunburst })),
   {
     loading: () => (
       <div className="h-[300px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
     ),
-    ssr: true,
+    ssr: false, // Recharts requires browser APIs
   }
 ) as ComponentType<any>;
 
-// Results chart components
+// ============================================================================
+// FORCE GRAPH COMPONENTS (react-force-graph-2d + d3-force - ~150KB gzipped)
+// ============================================================================
+
+/**
+ * Force Directed Graph - heavy D3-based visualization
+ * Requires browser canvas APIs
+ */
+export const ForceDirectedGraph = dynamic(
+  () => import('@/components/dashboard/charts/force-directed-graph').then(mod => ({ default: mod.ForceDirectedGraph })),
+  {
+    loading: () => (
+      <div className="h-[400px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg flex items-center justify-center">
+        <span className="text-slate-400 text-sm">Loading visualization...</span>
+      </div>
+    ),
+    ssr: false, // Force graph requires browser canvas APIs
+  }
+) as ComponentType<any>;
+
+// ============================================================================
+// RESULTS COMPONENTS (recharts)
+// ============================================================================
+
+/**
+ * History Chart - recharts based results history
+ */
 export const HistoryChart = dynamic(
   () => import('@/components/results/history-chart'),
   {
     loading: () => (
-      <div className="h-[250px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
+      <div className="h-[400px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
     ),
-    ssr: true,
+    ssr: false, // Recharts requires browser APIs
   }
 ) as ComponentType<any>;
 
+/**
+ * Score Gauge - framer-motion based
+ */
 export const ScoreGauge = dynamic(
   () => import('@/components/results/score-gauge'),
   {
     loading: () => (
       <div className="h-[180px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
     ),
-    ssr: true,
+    ssr: false, // Uses framer-motion animations
   }
 ) as ComponentType<any>;
 
-// PDF export - heavy libraries (jspdf, html2canvas)
+// ============================================================================
+// PDF EXPORT COMPONENTS (jspdf + html2canvas - ~180KB gzipped)
+// ============================================================================
+
+/**
+ * Export PDF - heavy libraries (jspdf, html2canvas)
+ * Only loaded when user clicks export button
+ */
 export const ExportPDF = dynamic(
   () => import('@/components/results/export-pdf').then(mod => ({ default: mod.ExportPDF })),
   {
-    loading: () => null, // Show button in loading state
+    loading: () => (
+      <button disabled className="opacity-50 cursor-not-allowed">
+        Loading...
+      </button>
+    ),
     ssr: false, // PDF generation requires browser APIs
   }
 ) as ComponentType<any>;
 
-// Mood trend chart
+// ============================================================================
+// JOURNAL COMPONENTS (recharts)
+// ============================================================================
+
+/**
+ * Mood Trend Chart - recharts based
+ */
 export const MoodTrend = dynamic(
   () => import('@/components/journal/mood-trend').then(mod => ({ default: mod.MoodTrend })),
   {
     loading: () => (
       <div className="h-[200px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
     ),
-    ssr: true,
+    ssr: false, // Recharts requires browser APIs
+  }
+) as ComponentType<any>;
+
+// ============================================================================
+// ONBOARDING COMPONENTS (framer-motion - ~40KB gzipped)
+// ============================================================================
+
+/**
+ * Onboarding Modal - framer-motion animations
+ * Lazy loaded since it's not needed for returning users
+ */
+export const OnboardingModal = dynamic(
+  () => import('@/components/onboarding/OnboardingModal').then(mod => ({ default: mod.OnboardingModal })),
+  {
+    loading: () => null, // Modal starts closed, no need for loading state
+    ssr: false,
+  }
+) as ComponentType<any>;
+
+/**
+ * Onboarding Wizard - framer-motion animations
+ */
+export const OnboardingWizard = dynamic(
+  () => import('@/components/onboarding/OnboardingWizard').then(mod => ({ default: mod.OnboardingWizard })),
+  {
+    loading: () => (
+      <div className="h-[400px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
+    ),
+    ssr: false,
+  }
+) as ComponentType<any>;
+
+// ============================================================================
+// GAMIFICATION COMPONENTS (framer-motion)
+// ============================================================================
+
+/**
+ * Achievement Gallery - framer-motion animations
+ */
+export const AchievementGallery = dynamic(
+  () => import('@/components/gamification/achievement-gallery').then(mod => ({ default: mod.AchievementGallery })),
+  {
+    loading: () => (
+      <div className="h-[300px] w-full animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
+    ),
+    ssr: false,
   }
 ) as ComponentType<any>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "SOUL_SENSE_EXAM",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Closes #959
Fixes #959


## 📌 Description
This PR implements aggressive code splitting to reduce the initial JavaScript bundle size below 200KB gzipped. Heavy libraries (recharts, framer-motion, jspdf, html2canvas, react-force-graph-2d) are now lazy-loaded only when users navigate to specific routes.

## Problem Statement
Deep code auditing revealed that massive libraries were being eagerly loaded in the global bundle:
- **recharts** (~70KB) - Loaded on all pages, only needed for dashboard/charts
- **framer-motion** (~40KB) - Loaded globally, only needed for animations
- **jspdf + html2canvas** (~180KB) - Loaded on all pages, only needed for PDF export
- **react-force-graph-2d + d3-force** (~150KB) - Only needed for visualization

This forced browsers to download a 500KB+ JavaScript payload before the login screen was interactive, devastating FCP and TTI metrics on slower mobile connections.

## Solution

### 1. Installed @next/bundle-analyzer
```bash
npm install --save-dev @next/bundle-analyzer cross-env
```

Added analyze script:
```json
"analyze": "cross-env ANALYZE=true next build"
```

### 2. Created Dynamic Imports Registry
**File:** `frontend-web/src/lib/dynamic-imports.tsx`

Created lazy-loaded wrappers for all heavy components with proper loading states and SSR configuration.

### 3. Updated Component Exports
Removed static exports from index files to prevent eager loading:
- `src/components/dashboard/index.ts`
- `src/components/results/index.ts`
- `src/components/journal/index.ts`

### 4. Updated Page Imports
Modified pages to use dynamic imports:
- `src/app/(app)/dashboard/page.tsx`
- `src/app/(app)/results/page.tsx`
- `src/app/(app)/results/[id]/page.tsx`
- `src/app/(app)/journal/page.tsx`

### 5. Next.js Config Updated
**File:** `frontend-web/next.config.js`

Wrapped config with `@next/bundle-analyzer` for conditional analysis.
