### PR TITLE
Wait loop event processing

### DIFF
--- a/BUSY_WAIT_LOOP_FIX.md
+++ b/BUSY_WAIT_LOOP_FIX.md
@@ -1,0 +1,54 @@
+# Busy-Wait Loop Fix for Event Processing (#1158)
+
+## Issue Description
+Event loop continuously polls without yielding, causing CPU starvation.
+
+**Objective:** Prevent CPU starvation.
+
+**Edge Cases:**
+- Empty queue loops
+- High-frequency polling
+
+**Test Cases:**
+- Observe CPU under idle state
+- Profiling event loop activity
+
+**Recommended Testing:**
+- Use `top`, `htop`
+- Async loop debug tools
+
+**Technical Implementation:**
+- Add `await asyncio.sleep()`
+- Replace polling with event-driven triggers
+
+## Solution Implemented
+
+### Changes Made
+
+1. **Added `subscribe()` and `unsubscribe()` methods to `KafkaProducerService`** (`backend/fastapi/api/services/kafka_producer.py`):
+   - `subscribe()`: Returns the `live_events` asyncio.Queue for local event consumption
+   - `unsubscribe()`: No-op for shared queue
+
+2. **Added `await asyncio.sleep(0)` after event processing** in event consumers:
+   - `cqrs_worker.py`: After processing CQRS events for Score entities
+   - `audit_consumer.py`: After persisting audit snapshots
+
+### How It Fixes the Issue
+
+- **Prevents CPU Starvation:** `sleep(0)` yields control to the event loop after each event, allowing other async tasks to run during high-frequency processing.
+
+- **Handles Empty Queues:** Existing `await q.get()` waits for events when queue is empty, preventing busy-waiting in idle states.
+
+- **Addresses High-Frequency Polling:** Yields after each event to maintain responsiveness.
+
+- **Event-Driven Design:** Maintains event-driven patterns with `await` on queue operations and Kafka consumer `getone()`.
+
+### Files Modified
+- `backend/fastapi/api/services/kafka_producer.py`
+- `backend/fastapi/api/services/cqrs_worker.py`
+- `backend/fastapi/api/services/audit_consumer.py`
+
+### Testing
+- Syntax validation passed
+- Ready for profiling with `top`/`htop` to verify CPU usage reduction under load</content>
+<parameter name="filePath">BUSY_WAIT_LOOP_FIX.md

--- a/backend/fastapi/api/services/audit_consumer.py
+++ b/backend/fastapi/api/services/audit_consumer.py
@@ -34,6 +34,9 @@ async def run_audit_consumer():
                 db.add(snapshot)
                 await db.commit()
                 # logger.debug(f"Audit event persisted: {event_data['entity']} {event_data['type']}")
+            
+            # Yield control to prevent CPU starvation
+            await asyncio.sleep(0)
 
         except asyncio.CancelledError:
             break

--- a/backend/fastapi/api/services/cqrs_worker.py
+++ b/backend/fastapi/api/services/cqrs_worker.py
@@ -63,6 +63,9 @@ async def run_cqrs_worker():
                 async with PrimarySessionLocal() as db:
                     await CQRSService.process_event(db, event_type, entity, event_data.get('payload', {}))
                     # logger.info(f"[CQRS] Updated projections for {entity} {event_type}")
+            
+            # Yield control to prevent CPU starvation during high-frequency events
+            await asyncio.sleep(0)
 
         except asyncio.CancelledError:
             if consumer: await consumer.stop()

--- a/backend/fastapi/api/services/kafka_producer.py
+++ b/backend/fastapi/api/services/kafka_producer.py
@@ -35,6 +35,14 @@ class KafkaProducerService:
         if self.producer:
             await self.producer.stop()
 
+    def subscribe(self):
+        """Subscribe to the live events queue for local event consumption."""
+        return self.live_events
+
+    def unsubscribe(self, q):
+        """Unsubscribe from the live events queue (no-op for shared queue)."""
+        pass
+
     def queue_event(self, event_data: dict):
         """Called by SQLAlchemy listeners. Non-blocking."""
         asyncio.create_task(self.send_event(event_data))


### PR DESCRIPTION
# Busy-Wait Loop Fix for Event Processing (#1158)

## Issue Description
Event loop continuously polls without yielding, causing CPU starvation.

**Objective:** Prevent CPU starvation.

**Edge Cases:**
- Empty queue loops
- High-frequency polling

**Test Cases:**
- Observe CPU under idle state
- Profiling event loop activity

**Recommended Testing:**
- Use `top`, `htop`
- Async loop debug tools

**Technical Implementation:**
- Add `await asyncio.sleep()`
- Replace polling with event-driven triggers

## Solution Implemented

### Changes Made

1. **Added `subscribe()` and `unsubscribe()` methods to `KafkaProducerService`** (`backend/fastapi/api/services/kafka_producer.py`):
   - `subscribe()`: Returns the `live_events` asyncio.Queue for local event consumption
   - `unsubscribe()`: No-op for shared queue

2. **Added `await asyncio.sleep(0)` after event processing** in event consumers:
   - `cqrs_worker.py`: After processing CQRS events for Score entities
   - `audit_consumer.py`: After persisting audit snapshots

### How It Fixes the Issue

- **Prevents CPU Starvation:** `sleep(0)` yields control to the event loop after each event, allowing other async tasks to run during high-frequency processing.

- **Handles Empty Queues:** Existing `await q.get()` waits for events when queue is empty, preventing busy-waiting in idle states.

- **Addresses High-Frequency Polling:** Yields after each event to maintain responsiveness.

- **Event-Driven Design:** Maintains event-driven patterns with `await` on queue operations and Kafka consumer `getone()`.

### Files Modified
- `backend/fastapi/api/services/kafka_producer.py`
- `backend/fastapi/api/services/cqrs_worker.py`
- `backend/fastapi/api/services/audit_consumer.py`

### Testing
- Syntax validation passed
- Ready for profiling with `top`/`htop` to verify CPU usage reduction under load</content>
<parameter name="filePath">BUSY_WAIT_LOOP_FIX.md


Closes #1158