### PR TITLE
Added Timestamp

### DIFF
--- a/backend/fastapi/api/models/__init__.py
+++ b/backend/fastapi/api/models/__init__.py
@@ -11,6 +11,7 @@ from sqlalchemy.engine import Engine, Connection
 from typing import List, Optional, Any, Dict, Tuple, Union
 from datetime import datetime, timedelta, UTC
 import logging
+from ..utils.timestamps import normalize_utc_iso, utc_now, utc_now_iso
 
 try:
     from ..services.encryption_service import EncryptedString
@@ -37,7 +38,7 @@ class User(Base):
     username = Column(String, unique=True, nullable=False)
     password_hash = Column(String, nullable=False)
     oauth_sub = Column(String, nullable=True, unique=True)  # OAuth subject identifier
-    created_at = Column(String, default=lambda: datetime.now(UTC).isoformat())
+    created_at = Column(String, default=utc_now_iso)
     last_login = Column(String, nullable=True)
     
     # PR 1: Security & Lifecycle Fields
@@ -305,7 +306,7 @@ class OutboxEvent(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     topic = Column(String, default="audit_trail", nullable=False)
     payload = Column(JSON, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow, index=True)
+    created_at = Column(DateTime, default=utc_now, index=True)
     status = Column(String, default='pending', index=True) # pending, processed, failed
     processed_at = Column(DateTime, nullable=True)
     retry_count = Column(Integer, default=0)
@@ -338,8 +339,8 @@ class GDPRScrubLog(Base):
     retry_count = Column(Integer, default=0)
     last_error = Column(Text, nullable=True)
     
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
 
 class AnalyticsEvent(Base):
     """Track user behavior events (e.g., signup drop-off).
@@ -419,7 +420,7 @@ class OTP(Base):
     is_used = Column(Boolean, default=False, index=True)
     attempts = Column(Integer, default=0)
     is_locked = Column(Boolean, default=False)
-    created_at = Column(DateTime, default=datetime.utcnow, index=True)
+    created_at = Column(DateTime, default=utc_now, index=True)
     user = relationship("User", back_populates="otps")
 
 class PasswordHistory(Base):
@@ -430,7 +431,7 @@ class PasswordHistory(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey('users.id'), nullable=False, index=True)
     password_hash = Column(String, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow, index=True)
+    created_at = Column(DateTime, default=utc_now, index=True)
     user = relationship("User", back_populates="password_history")
 
 class RefreshToken(Base):
@@ -443,7 +444,7 @@ class RefreshToken(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey('users.id'), nullable=False, index=True)
     token_hash = Column(String, unique=True, index=True, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow, index=True)
+    created_at = Column(DateTime, default=utc_now, index=True)
     expires_at = Column(DateTime, nullable=False, index=True)
     is_revoked = Column(Boolean, default=False, index=True)
     user = relationship("User", back_populates="refresh_tokens")
@@ -467,7 +468,7 @@ class UserSession(Base):
     user_agent = Column(String, nullable=True)
     is_active = Column(Boolean, default=True)
     last_activity = Column(DateTime, default=datetime.utcnow)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utc_now)
     
     user = relationship("User", back_populates="sessions")
     
@@ -504,7 +505,7 @@ class UserSettings(Base):
     
     # Crisis support settings (Integration with emotional support features)
     crisis_support_preference = Column(Boolean, default=True)
-    updated_at = Column(String, default=lambda: datetime.utcnow().isoformat())
+    updated_at = Column(String, default=utc_now_iso)
     user = relationship("User", back_populates="settings")
 
 class MedicalProfile(Base):
@@ -544,7 +545,7 @@ class PersonalProfile(Base):
     sleep_hours = Column(Float, nullable=True)
     exercise_freq = Column(String, nullable=True)
     dietary_patterns = Column(String, nullable=True)
-    last_updated = Column(String, default=lambda: datetime.utcnow().isoformat())
+    last_updated = Column(String, default=utc_now_iso)
     user = relationship("User", back_populates="personal_profile")
 
 class UserStrengths(Base):
@@ -558,7 +559,7 @@ class UserStrengths(Base):
     communication_preference = Column(String, nullable=True)
     primary_help_area = Column(String, nullable=True)
     relationship_stress = Column(Integer, nullable=True)
-    last_updated = Column(String, default=lambda: datetime.utcnow().isoformat())
+    last_updated = Column(String, default=utc_now_iso)
     user = relationship("User", back_populates="strengths")
 
 class UserEmotionalPatterns(Base):
@@ -1121,7 +1122,7 @@ class ExportRecord(Base):
     data_types = Column(Text, nullable=True)
     is_encrypted = Column(Boolean, default=False, nullable=False)
     status = Column(String, default='completed', nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    created_at = Column(DateTime, default=utc_now, nullable=False, index=True)
     expires_at = Column(DateTime, nullable=True)
     user = relationship("User", back_populates="export_records")
 
@@ -1237,7 +1238,7 @@ class BackgroundJob(Base):
     params = Column(Text, nullable=True)  # JSON string of task parameters
     result = Column(Text, nullable=True)  # JSON string of task result
     error_message = Column(Text, nullable=True)  # Error details if failed
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utc_now, nullable=False)
     started_at = Column(DateTime, nullable=True)  # When task started processing
     completed_at = Column(DateTime, nullable=True)  # When task finished
     updated_at = Column(DateTime, default=datetime.utcnow, nullable=False)
@@ -1324,7 +1325,7 @@ class UserConsent(Base):
     revoked_at = Column(DateTime, nullable=True)
     ip_address = Column(String(45), nullable=True)
     user_agent = Column(Text, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utc_now, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     
     def to_dict(self):
@@ -1351,6 +1352,12 @@ logging.basicConfig(level=logging.INFO)
 # ==================== CACHE INVALIDATION EVENTS ====================
 
 from sqlalchemy import event
+
+
+@event.listens_for(User, 'before_insert')
+@event.listens_for(User, 'before_update')
+def normalize_user_created_at(mapper, connection, target):
+    target.created_at = normalize_utc_iso(getattr(target, 'created_at', None), fallback_now=True)
 
 @event.listens_for(User, 'after_update')
 def receive_after_update_user(mapper, connection, target):

--- a/backend/fastapi/api/routers/auth.py
+++ b/backend/fastapi/api/routers/auth.py
@@ -14,6 +14,7 @@ from ..services.db_router import get_db
 from ..services.auth_service import AuthService
 from ..services.captcha_service import captcha_service
 from ..utils.network import get_real_ip
+from ..utils.timestamps import normalize_utc_iso
 from ..constants.security_constants import REFRESH_TOKEN_EXPIRE_DAYS
 from ..models import User
 from ..utils.limiter import limiter
@@ -102,7 +103,7 @@ async def get_current_user(request: Request, token: Annotated[str, Depends(oauth
         user_data = {
             "id": user.id,
             "username": user.username,
-            "created_at": user.created_at,
+            "created_at": normalize_utc_iso(user.created_at, fallback_now=True),
             "last_login": user.last_login,
             "is_active": user.is_active,
             "is_deleted": user.is_deleted,
@@ -232,7 +233,7 @@ async def login(
         username=user.username,
         email=user.personal_profile.email if user.personal_profile else None,
         id=user.id,
-        created_at=user.created_at,
+        created_at=normalize_utc_iso(user.created_at, fallback_now=True),
         warnings=(
             [{
                 "code": "MULTIPLE_SESSIONS_ACTIVE",
@@ -303,7 +304,7 @@ async def verify_2fa(
         username=user.username,
         email=user.personal_profile.email if user.personal_profile else None,
         id=user.id,
-        created_at=user.created_at,
+        created_at=normalize_utc_iso(user.created_at, fallback_now=True),
         warnings=(
             [{
                 "code": "MULTIPLE_SESSIONS_ACTIVE",
@@ -396,7 +397,11 @@ async def logout(
 
 @router.get("/me", response_model=UserResponse)
 async def read_users_me(current_user: Annotated[User, Depends(get_current_user)]):
-    return UserResponse(id=current_user.id, username=current_user.username, created_at=current_user.created_at)
+    return UserResponse(
+        id=current_user.id,
+        username=current_user.username,
+        created_at=normalize_utc_iso(current_user.created_at, fallback_now=True),
+    )
 
 @router.post("/password-reset/initiate")
 async def initiate_password_reset(
@@ -595,7 +600,7 @@ async def oauth_login(
             username=user.username,
             email=getattr(user.personal_profile, 'email', None) if user.personal_profile else user_info.get("email"),
             id=user.id,
-            created_at=user.created_at,
+            created_at=normalize_utc_iso(user.created_at, fallback_now=True),
             warnings=[],
             onboarding_completed=getattr(user, "onboarding_completed", False),
             is_admin=getattr(user, "is_admin", False)

--- a/backend/fastapi/api/routers/tasks.py
+++ b/backend/fastapi/api/routers/tasks.py
@@ -18,6 +18,7 @@ from ..services.background_task_service import (
 )
 from ..models import User, BackgroundJob
 from .auth import get_current_user
+from ..utils.timestamps import normalize_utc_iso
 from app.core import NotFoundError, ValidationError
 from pydantic import BaseModel, Field
 
@@ -97,9 +98,9 @@ async def get_task_status(
         progress=task.progress or 0,
         result=_parse_json_field(task.result),
         error_message=task.error_message,
-        created_at=task.created_at.isoformat() if task.created_at else None,
-        started_at=task.started_at.isoformat() if task.started_at else None,
-        completed_at=task.completed_at.isoformat() if task.completed_at else None,
+        created_at=normalize_utc_iso(task.created_at),
+        started_at=normalize_utc_iso(task.started_at),
+        completed_at=normalize_utc_iso(task.completed_at),
     )
 
 
@@ -142,9 +143,9 @@ async def list_user_tasks(
             progress=task.progress or 0,
             result=_parse_json_field(task.result),
             error_message=task.error_message,
-            created_at=task.created_at.isoformat() if task.created_at else None,
-            started_at=task.started_at.isoformat() if task.started_at else None,
-            completed_at=task.completed_at.isoformat() if task.completed_at else None,
+            created_at=normalize_utc_iso(task.created_at),
+            started_at=normalize_utc_iso(task.started_at),
+            completed_at=normalize_utc_iso(task.completed_at),
         )
         for task in tasks
     ]

--- a/backend/fastapi/api/routers/users.py
+++ b/backend/fastapi/api/routers/users.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends, status, UploadFile, File, Request
 from pathlib import Path
 from ..utils.limiter import limiter
+from ..utils.timestamps import normalize_utc_iso
 
 from ..schemas import (
     UserResponse,
@@ -58,7 +59,7 @@ async def get_current_user_info(
     return UserResponse(
         id=current_user.id,
         username=current_user.username,
-        created_at=current_user.created_at,
+        created_at=normalize_utc_iso(current_user.created_at, fallback_now=True),
         last_login=current_user.last_login
     )
 
@@ -107,7 +108,7 @@ async def update_current_user(
     return UserResponse(
         id=updated_user.id,
         username=updated_user.username,
-        created_at=updated_user.created_at,
+        created_at=normalize_utc_iso(updated_user.created_at, fallback_now=True),
         last_login=updated_user.last_login
     )
 
@@ -162,7 +163,7 @@ async def list_users(
         UserResponse(
             id=user.id,
             username=user.username,
-            created_at=user.created_at,
+            created_at=normalize_utc_iso(user.created_at, fallback_now=True),
             last_login=user.last_login
         )
         for user in users
@@ -185,7 +186,7 @@ async def get_user(
     return UserResponse(
         id=user.id,
         username=user.username,
-        created_at=user.created_at,
+        created_at=normalize_utc_iso(user.created_at, fallback_now=True),
         last_login=user.last_login
     )
 

--- a/backend/fastapi/api/services/auth_service.py
+++ b/backend/fastapi/api/services/auth_service.py
@@ -18,6 +18,7 @@ from .audit_service import AuditService
 from ..utils.db_transaction import transactional, retry_on_transient
 from ..utils.security import get_password_hash, verify_password, is_hashed, check_password_history
 from ..utils.race_condition_protection import with_row_lock
+from ..utils.timestamps import utc_now_iso
 from ..models import User, LoginAttempt, PersonalProfile, RefreshToken, PasswordHistory
 from ..constants.security_constants import PASSWORD_HISTORY_LIMIT, REFRESH_TOKEN_EXPIRE_DAYS
 from .db_router import mark_write
@@ -729,7 +730,7 @@ class AuthService:
             username=username,
             password_hash="",
             oauth_sub=sub,
-            created_at=datetime.now(timezone.utc).isoformat()
+            created_at=utc_now_iso()
         )
         self.db.add(user)
         await self.db.flush()

--- a/backend/fastapi/api/services/profile_service.py
+++ b/backend/fastapi/api/services/profile_service.py
@@ -26,6 +26,7 @@ from ..models import (
     UserStrengths,
     UserEmotionalPatterns
 )
+from ..utils.timestamps import normalize_utc_iso
 from .db_error_handler import safe_db_query, DatabaseConnectionError
 import logging
 
@@ -452,7 +453,7 @@ class ProfileService:
             "user": {
                 "id": user.id,
                 "username": user.username,
-                "created_at": user.created_at,
+                "created_at": normalize_utc_iso(user.created_at, fallback_now=True),
                 "last_login": user.last_login,
                 "onboarding_completed": user.onboarding_completed or False
             },

--- a/backend/fastapi/api/services/user_service.py
+++ b/backend/fastapi/api/services/user_service.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException, status
 
 # Import models from models module
 from ..models import User, UserSettings, MedicalProfile, PersonalProfile, UserStrengths, UserEmotionalPatterns, Score, UserSession
+from ..utils.timestamps import utc_now_iso
 from .db_error_handler import safe_db_query, DatabaseConnectionError
 import bcrypt
 import logging
@@ -112,7 +113,7 @@ class UserService:
         new_user = User(
             username=username,
             password_hash=password_hash,
-            created_at=datetime.now(UTC).isoformat()
+            created_at=utc_now_iso()
         )
 
         try:

--- a/backend/fastapi/api/utils/timestamps.py
+++ b/backend/fastapi/api/utils/timestamps.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Optional, Union
+
+
+TimestampLike = Union[datetime, str]
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def utc_now_iso() -> str:
+    return utc_now().isoformat()
+
+
+def parse_timestamp(value: TimestampLike) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None
+
+        if candidate.endswith("Z"):
+            candidate = f"{candidate[:-1]}+00:00"
+
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            parsed = None
+            formats = (
+                "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%d %H:%M:%S.%f",
+                "%Y-%m-%dT%H:%M:%S",
+                "%Y-%m-%dT%H:%M:%S.%f",
+            )
+            for fmt in formats:
+                try:
+                    parsed = datetime.strptime(candidate, fmt)
+                    break
+                except ValueError:
+                    continue
+
+            if parsed is None:
+                return None
+    else:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def normalize_utc_iso(value: Optional[TimestampLike], *, fallback_now: bool = False) -> Optional[str]:
+    parsed = parse_timestamp(value) if value is not None else None
+    if parsed is None:
+        if fallback_now:
+            return utc_now_iso()
+        return None
+    return parsed.isoformat()

--- a/backend/fastapi/tests/integration/test_tasks_api.py
+++ b/backend/fastapi/tests/integration/test_tasks_api.py
@@ -31,7 +31,7 @@ class TestTasksAPI:
     @pytest.fixture
     def mock_job(self):
         """Create a mock background job."""
-        from datetime import datetime
+        from datetime import UTC, datetime
         job = Mock()
         job.job_id = "test-job-uuid-123"
         job.user_id = 1
@@ -41,20 +41,20 @@ class TestTasksAPI:
         job.params = '{"format": "pdf"}'
         job.result = None
         job.error_message = None
-        job.created_at = datetime.utcnow()
+        job.created_at = datetime.now(UTC)
         job.started_at = None
         job.completed_at = None
-        job.updated_at = datetime.utcnow()
+        job.updated_at = datetime.now(UTC)
         return job
     
     @pytest.fixture
     def mock_completed_job(self, mock_job):
         """Create a mock completed job."""
-        from datetime import datetime
+        from datetime import UTC, datetime
         mock_job.status = "completed"
         mock_job.progress = 100
         mock_job.result = '{"filepath": "/exports/test.pdf", "export_id": "export-123"}'
-        mock_job.completed_at = datetime.utcnow()
+        mock_job.completed_at = datetime.now(UTC)
         return mock_job
     
     def test_async_export_returns_202(self, mock_user):
@@ -101,6 +101,7 @@ class TestTasksAPI:
                 assert data["job_id"] == mock_job.job_id
                 assert data["status"] == "pending"
                 assert data["task_type"] == "export_pdf"
+                assert data["created_at"].endswith("+00:00")
     
     def test_get_task_not_found(self, mock_user):
         """Test 404 when task not found."""
@@ -157,6 +158,7 @@ class TestTasksAPI:
                 data = response.json()
                 assert data["total"] == 1
                 assert len(data["tasks"]) == 1
+                assert data["tasks"][0]["created_at"].endswith("+00:00")
     
     def test_list_tasks_with_filter(self, mock_user, mock_job):
         """Test listing tasks with status filter."""

--- a/backend/fastapi/tests/unit/test_background_task_service.py
+++ b/backend/fastapi/tests/unit/test_background_task_service.py
@@ -11,7 +11,7 @@ Tests cover:
 
 import pytest
 from unittest.mock import Mock, patch, MagicMock
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import json
 
 from api.services.background_task_service import (
@@ -47,10 +47,10 @@ class TestBackgroundTaskService:
         job.params = None
         job.result = None
         job.error_message = None
-        job.created_at = datetime.utcnow()
+        job.created_at = datetime.now(UTC)
         job.started_at = None
         job.completed_at = None
-        job.updated_at = datetime.utcnow()
+        job.updated_at = datetime.now(UTC)
         return job
     
     def test_create_task_success(self, mock_db):

--- a/backend/fastapi/tests/unit/test_timestamps.py
+++ b/backend/fastapi/tests/unit/test_timestamps.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime, timedelta, timezone
+
+from api.utils.timestamps import normalize_utc_iso, utc_now_iso
+
+
+def test_normalize_utc_iso_from_naive_datetime():
+    value = datetime(2026, 3, 1, 10, 0, 0)
+    normalized = normalize_utc_iso(value)
+
+    assert normalized == "2026-03-01T10:00:00+00:00"
+
+
+def test_normalize_utc_iso_from_offset_datetime():
+    value = datetime(2026, 3, 1, 10, 0, 0, tzinfo=timezone(timedelta(hours=5, minutes=30)))
+    normalized = normalize_utc_iso(value)
+
+    assert normalized == "2026-03-01T04:30:00+00:00"
+
+
+def test_normalize_utc_iso_from_zulu_string():
+    normalized = normalize_utc_iso("2026-03-01T10:00:00Z")
+
+    assert normalized == "2026-03-01T10:00:00+00:00"
+
+
+def test_normalize_utc_iso_from_naive_iso_string():
+    normalized = normalize_utc_iso("2026-03-01T10:00:00")
+
+    assert normalized == "2026-03-01T10:00:00+00:00"
+
+
+def test_normalize_utc_iso_fallback_now_for_invalid_values():
+    normalized = normalize_utc_iso("not-a-date", fallback_now=True)
+
+    assert normalized is not None
+    assert normalized.endswith("+00:00")
+
+
+def test_utc_now_iso_is_utc():
+    ts = utc_now_iso()
+    parsed = datetime.fromisoformat(ts)
+
+    assert parsed.tzinfo == UTC

--- a/migrations/versions/20260301_093000_normalize_users_created_at_utc_iso.py
+++ b/migrations/versions/20260301_093000_normalize_users_created_at_utc_iso.py
@@ -1,0 +1,84 @@
+"""normalize_users_created_at_utc_iso
+
+Revision ID: 20260301_093000
+Revises: f0e1d2c3b4a5
+Create Date: 2026-03-01 09:30:00.000000
+
+"""
+from datetime import UTC, datetime
+from typing import Optional, Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20260301_093000'
+down_revision: Union[str, Sequence[str], None] = 'f0e1d2c3b4a5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _normalize_utc_iso(value: object) -> Optional[str]:
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None
+
+        if candidate.endswith("Z"):
+            candidate = f"{candidate[:-1]}+00:00"
+
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            parsed = None
+            for fmt in (
+                "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%d %H:%M:%S.%f",
+                "%Y-%m-%dT%H:%M:%S",
+                "%Y-%m-%dT%H:%M:%S.%f",
+            ):
+                try:
+                    parsed = datetime.strptime(candidate, fmt)
+                    break
+                except ValueError:
+                    continue
+
+            if parsed is None:
+                return None
+    else:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    else:
+        parsed = parsed.astimezone(UTC)
+
+    return parsed.isoformat()
+
+
+def upgrade() -> None:
+    """Normalize legacy users.created_at values to strict UTC ISO 8601."""
+    conn = op.get_bind()
+
+    rows = conn.execute(sa.text("SELECT id, created_at FROM users")).mappings().all()
+    for row in rows:
+        normalized = _normalize_utc_iso(row["created_at"])
+        if normalized is None:
+            normalized = datetime.now(UTC).isoformat()
+
+        if normalized != row["created_at"]:
+            conn.execute(
+                sa.text("UPDATE users SET created_at = :created_at WHERE id = :id"),
+                {"id": row["id"], "created_at": normalized},
+            )
+
+
+def downgrade() -> None:
+    """No-op: data normalization is intentionally non-reversible."""
+    pass

--- a/migrations/versions/f0e1d2c3b4a5_add_environment_separation_columns.py
+++ b/migrations/versions/f0e1d2c3b4a5_add_environment_separation_columns.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'f0e1d2c3b4a5'
-down_revision: Union[str, Sequence[str], None] = '20260227_160145_add_performance_indexes'
+down_revision: Union[str, Sequence[str], None] = '20260227_160145'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
Closes #1053 
Fixes #1053 

# Fix: Inconsistent `created_at` timestamp format (#1053)

## Summary
This PR standardizes `created_at` handling to **UTC ISO 8601** across write paths, API responses, and legacy data migration.

It resolves mixed timestamp formats (naive datetime, timezone-unaware strings, and inconsistent ISO outputs) that caused sorting inconsistencies, parsing issues on frontend clients, and timezone-related bugs.

---

## Problem
Different endpoints and model paths were emitting/storing `created_at` using mixed patterns:
- `datetime.utcnow()` / naive `datetime`
- direct raw string values from legacy records
- ad-hoc `.isoformat()` usage without timezone normalization

This led to:
- incorrect ordering when sorting by `created_at`
- frontend parse variability
- UTC drift / timezone ambiguity

---

## What changed

### 1) Centralized timestamp normalization utilities
Added shared utility module:
- `backend/fastapi/api/utils/timestamps.py`

Key helpers:
- `utc_now()`
- `utc_now_iso()`
- `parse_timestamp(value)`
- `normalize_utc_iso(value, fallback_now=False)`

Behavior:
- accepts `datetime` or string input
- normalizes naive values as UTC
- supports `Z` suffix and common legacy datetime formats
- always returns UTC ISO 8601 string when normalization succeeds

### 2) Enforced UTC defaults and normalization in models
Updated model defaults to use UTC-aware helpers and added guardrails:
- `backend/fastapi/api/models/__init__.py`

Highlights:
- `User.created_at` default now uses `utc_now_iso`
- several `DateTime created_at` defaults switched from `datetime.utcnow` to `utc_now`
- SQLAlchemy event hooks added for `User`:
  - `before_insert`
  - `before_update`
  - normalize `created_at` via `normalize_utc_iso(..., fallback_now=True)`

### 3) Normalized API serialization output
Ensured response payloads consistently return UTC ISO strings:
- `backend/fastapi/api/routers/auth.py`
- `backend/fastapi/api/routers/users.py`
- `backend/fastapi/api/routers/tasks.py`
- `backend/fastapi/api/services/profile_service.py`

### 4) Standardized user creation paths
Replaced direct timestamp creation with shared utility in service flows:
- `backend/fastapi/api/services/user_service.py`
- `backend/fastapi/api/services/auth_service.py`

### 5) Legacy data normalization migration
Added migration to normalize existing `users.created_at` records:
- `migrations/versions/20260301_093000_normalize_users_created_at_utc_iso.py`

Migration behavior:
- reads all `users.created_at`
- normalizes each value to UTC ISO 8601
- if value is invalid/null, falls back to current UTC ISO timestamp
- intentionally non-reversible data transformation (`downgrade` is no-op)

### 6) Migration chain fix discovered while validating
Fixed an existing Alembic revision reference typo that blocked migration graph resolution:
- `migrations/versions/f0e1d2c3b4a5_add_environment_separation_columns.py`
  - corrected `down_revision` from `20260227_160145_add_performance_indexes` to `20260227_160145`

### 7) Tests
Added/updated tests to validate normalization behavior:
- **New**: `backend/fastapi/tests/unit/test_timestamps.py`
- **Updated**: `backend/fastapi/tests/integration/test_tasks_api.py`
- **Updated**: `backend/fastapi/tests/unit/test_background_task_service.py`

---

## Acceptance criteria mapping
- [x] All new `created_at` writes are UTC-normalized
- [x] Timestamp format is normalized to ISO 8601 UTC in key API responses
- [x] Naive datetime handling is normalized through shared utility + model event hooks
- [x] Legacy `users.created_at` data normalized via migration
- [x] Frontend-facing task/user/auth payloads emit consistent parseable ISO timestamps

---

## Verification performed

### Passed
```bash
python -m pytest backend/fastapi/tests/unit/test_timestamps.py -q
# 6 passed
```

### Note on broader suite
A pre-existing unrelated model/index mismatch currently blocks full task test collection in this branch context:
- `scores` index references missing `environment` column during import/collection.

This issue is outside the timestamp-format fix itself.

---

## Risk assessment
- **Data risk**: low-medium (one-time normalization of historical `users.created_at`)
- **Runtime risk**: low (centralized formatting helper + additive normalization)
- **API compatibility**: maintained (`created_at` remains string-like ISO output, now consistent UTC)

---

## Rollback plan
1. Revert code changes in routers/services/models.
2. If needed, skip the normalization migration in downgrade workflow (data transformation is non-reversible by design).
3. Restore previous behavior by removing normalization event hooks and utility calls.

---

## Checklist
- [x] Centralized timestamp utility added
- [x] Model defaults updated to UTC-aware paths
- [x] API response normalization applied
- [x] Legacy normalization migration added
- [x] Targeted tests added/updated
- [x] Unit test verification executed
Closes #1053