### PR TITLE
ISSUE-1146: Implement Outbox Purgatory Cleanup and Dead-Letter Handling

### DIFF
--- a/backend/fastapi/api/api/v1/router.py
+++ b/backend/fastapi/api/api/v1/router.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter
-
 from ...routers import (
     auth, users, profiles, assessments, 
     questions, analytics, journal, health,
     settings_sync, community, contact, exams, export, deep_dive,
-    gamification, audit, tasks, consent, surveys, advanced_analytics, archival, notifications, flags, search, team_vision
+    gamification, audit, tasks, consent, surveys, advanced_analytics, 
+    archival, notifications, flags, search, team_vision, admin
 )
 
 api_router = APIRouter()
@@ -36,4 +36,5 @@ api_router.include_router(tasks.router, prefix="/tasks", tags=["Background Tasks
 api_router.include_router(consent.router, prefix="/consent", tags=["Consent"])
 api_router.include_router(surveys.router, prefix="/surveys", tags=["Surveys"])
 api_router.include_router(flags.router, prefix="/admin/flags", tags=["Feature Flags"])
+api_router.include_router(admin.router, prefix="/admin", tags=["System Administration"])
 

--- a/backend/fastapi/api/routers/__init__.py
+++ b/backend/fastapi/api/routers/__init__.py
@@ -2,7 +2,7 @@ from . import (
     health, assessments, auth, users, profiles, analytics, 
     questions, journal, settings_sync, community, contact, 
     exams, export, deep_dive, gamification, audit, tasks, consent,
-    surveys, advanced_analytics, archival, notifications, flags
+    surveys, advanced_analytics, archival, notifications, flags, admin
 )
 
 __all__ = [
@@ -10,6 +10,6 @@ __all__ = [
     "analytics", "questions", "journal", "settings_sync", 
     "community", "contact", "exams", "export", "deep_dive",
     "gamification", "audit", "tasks", "consent", "surveys",
-    "advanced_analytics", "archival", "notifications", "flags"
+    "advanced_analytics", "archival", "notifications", "flags", "admin"
 ]
 

--- a/backend/fastapi/api/routers/admin.py
+++ b/backend/fastapi/api/routers/admin.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Dict, Any
+
+from ..services.db_service import get_db
+from ..services.outbox_relay_service import OutboxRelayService
+from ..models import User
+from .auth import require_admin
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+@router.get("/outbox/stats", response_model=Dict[str, int])
+async def get_outbox_stats(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_admin)
+):
+    """
+    Requirement ISSUE-1146: Get health statistics for the Transactional Outbox.
+    Returns counts of events by status (pending, processed, failed).
+    """
+    stats = await OutboxRelayService.get_outbox_stats(db)
+    return stats
+
+@router.post("/outbox/retry-failed", response_model=Dict[str, Any])
+async def retry_failed_outbox_events(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_admin)
+):
+    """
+    Requirement ISSUE-1146: Manually retry all failed (dead-lettered) outbox events.
+    Resets status to 'pending' and retry_count to 0.
+    """
+    count = await OutboxRelayService.retry_all_failed_events(db)
+    return {
+        "message": f"Successfully reset {count} failed events to pending status.",
+        "reset_count": count
+    }
+
+@router.get("/health", response_model=Dict[str, Any])
+async def admin_health_check(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_admin)
+):
+    """General admin-only health check that includes system internals."""
+    outbox_stats = await OutboxRelayService.get_outbox_stats(db)
+    total_purgatory = outbox_stats.get("pending", 0) + outbox_stats.get("failed", 0)
+    
+    status = "healthy"
+    if total_purgatory > 10000:
+        status = "degraded (outbox_purgatory)"
+    
+    return {
+        "status": status,
+        "outbox": outbox_stats,
+        "is_admin": True
+    }

--- a/backend/fastapi/api/services/outbox_relay_service.py
+++ b/backend/fastapi/api/services/outbox_relay_service.py
@@ -123,22 +123,64 @@ class OutboxRelayService:
                 event.retry_count = (event.retry_count or 0) + 1
                 event.error_message = str(e)
 
-                if event.retry_count >= 10:
+                # Requirement ISSUE-1146: Move to 'failed' status after 3 attempts
+                if event.retry_count >= 3:
                     event.status = "failed"
                     logger.critical(
-                        f"[Outbox] Permanently aborting event {event.id} after {event.retry_count} retries."
+                        f"[Outbox] DEAD-LETTER: Permanently aborting event {event.id} after {event.retry_count} retries."
                     )
                 else:
-                    delay_seconds = 30 * (2 ** (event.retry_count - 1))  # 30s, 60s, 120s ... up to ~4.3h
+                    # Exponential backoff: 30s, 60s, 120s
+                    delay_seconds = 30 * (2 ** (event.retry_count - 1))
                     event.next_retry_at = event_now + timedelta(seconds=delay_seconds)
                     logger.warning(
                         f"[Outbox] Scheduled retry for event {event.id} "
-                        f"in {delay_seconds}s (attempt {event.retry_count}/10)"
+                        f"in {delay_seconds}s (attempt {event.retry_count}/3)"
                     )
 
         # Single batch commit after all events are processed
         await db.commit()
+
+        # Requirement ISSUE-1146: Purgatory Cleanup / Alert System
+        # Check global health of outbox after processing a batch
+        stats = await OutboxRelayService.get_outbox_stats(db)
+        total_purgatory = stats.get("pending", 0) + stats.get("failed", 0)
+        
+        if total_purgatory > 10000:
+            logger.critical(
+                f"[Outbox] PURGATORY ALERT: {total_purgatory} messages stuck in outbox! "
+                f"(Pending: {stats.get('pending')}, Failed: {stats.get('failed')}). "
+                "Immediate administrator intervention required."
+            )
+
         return processed_count
+
+    @staticmethod
+    async def get_outbox_stats(db: AsyncSession) -> dict:
+        """Requirement ISSUE-1146: Get health statistics for the outbox."""
+        from sqlalchemy import func
+        stmt = select(OutboxEvent.status, func.count(OutboxEvent.id)).group_by(OutboxEvent.status)
+        result = await db.execute(stmt)
+        return {status: count for status, count in result.all()}
+
+    @staticmethod
+    async def retry_all_failed_events(db: AsyncSession) -> int:
+        """Requirement ISSUE-1146: Manual trigger to retry all dead-lettered events."""
+        from sqlalchemy import update
+        stmt = (
+            update(OutboxEvent)
+            .where(OutboxEvent.status == "failed")
+            .values(
+                status="pending",
+                retry_count=0,
+                next_retry_at=datetime.now(UTC),
+                error_message=None
+            )
+        )
+        result = await db.execute(stmt)
+        await db.commit()
+        logger.info(f"[Outbox] Reset {result.rowcount} failed events back to pending.")
+        return result.rowcount
 
     @classmethod
     async def start_relay_worker(cls, async_session_factory, interval_seconds: int = 2):


### PR DESCRIPTION
close #1146 
 Implementation Summary
Refined Exponential Backoff & Dead-Lettering:

Updated 

OutboxRelayService
 to enforce a strict 3-retry limit.
If a message fails 3 times, it is moved to 

failed
 status (Dead-Lettered) to prevent blocking the relay pipe.
Standardized the backoff delay to 30s, 60s, and 120s.
Purgatory Alert System:

Added a health check within the relay batch processor.
If the total of 

pending
 and 

failed
 outbox messages exceeds 10,000, the system logs a CRITICAL alert to notify administrators of a potential data sync "Purgatory".
New Administrator Router:

Created 

api/routers/admin.py
 (registered under /api/v1/admin).
GET /outbox/stats: Provides a breakdown of outbox health (counts of pending, processed, and failed messages).
POST /outbox/retry-failed: Allows an administrator to manually reset all 

failed
 messages back to 

pending
 with a fresh retry count.
GET /health: A privileged health check returning system-wide outbox and relay status.

