### PR TITLE
feat: Enable journal entry editing with timestamp tracking

### DIFF
--- a/backend/fastapi/api/models/__init__.py
+++ b/backend/fastapi/api/models/__init__.py
@@ -777,6 +777,7 @@ class JournalEntry(Base):
     sentiment_score = Column(Float, default=0.0)
     emotional_patterns = Column(Text, nullable=True) # JSON list
     timestamp = Column(String, default=lambda: datetime.now(UTC).isoformat(), index=True)
+    updated_at = Column(String, default=lambda: datetime.now(UTC).isoformat(), nullable=True)
     entry_date = Column(String, nullable=True, index=True) # For legacy/charting
     category = Column(String, nullable=True, index=True)
     mood_score = Column(Integer, nullable=True) # 1-10

--- a/backend/fastapi/api/schemas/__init__.py
+++ b/backend/fastapi/api/schemas/__init__.py
@@ -1188,6 +1188,7 @@ class JournalResponse(BaseModel):
     tags: Optional[List[str]] = []
     entry_date: str
     timestamp: str
+    updated_at: Optional[str] = Field(None, description="Last modification timestamp (Issue #1330)")
     word_count: int = Field(default=0, description="Number of words in content")
     reading_time_mins: Optional[float] = Field(None, description="Estimated reading time in minutes")
     privacy_level: str = Field(default="private")

--- a/backend/fastapi/api/services/journal_service.py
+++ b/backend/fastapi/api/services/journal_service.py
@@ -427,6 +427,9 @@ class JournalService:
             if hasattr(entry, key):
                 setattr(entry, key, value)
         
+        # Update the timestamp to reflect modification (Issue #1330)
+        entry.updated_at = datetime.now(UTC).isoformat()
+        
         try:
             await self.db.commit()
             await self.db.refresh(entry)

--- a/frontend-web/src/app/(app)/journal/page.tsx
+++ b/frontend-web/src/app/(app)/journal/page.tsx
@@ -35,8 +35,8 @@ function adaptEntry(entry: any) {
       (entry.sentiment_score ? Math.round((entry.sentiment_score + 1) * 5) : undefined),
     tags: entry.tags || [],
     sentiment_score: entry.sentiment_score,
-    created_at: entry.timestamp,
-    updated_at: entry.timestamp,
+    created_at: entry.updated_at || entry.timestamp,
+    updated_at: entry.updated_at || entry.timestamp,
   };
 }
 

--- a/frontend-web/src/components/journal/journal-list.tsx
+++ b/frontend-web/src/components/journal/journal-list.tsx
@@ -13,8 +13,8 @@ function adaptEntry(entry: any) {
       (entry.sentiment_score ? Math.round((entry.sentiment_score + 1) * 5) : undefined),
     tags: entry.tags || [],
     sentiment_score: entry.sentiment_score,
-    created_at: entry.timestamp,
-    updated_at: entry.timestamp,
+    created_at: entry.updated_at || entry.timestamp,
+    updated_at: entry.updated_at || entry.timestamp,
   };
 }
 

--- a/migrations/versions/1330_add_updated_at_to_journal_entries.py
+++ b/migrations/versions/1330_add_updated_at_to_journal_entries.py
@@ -1,0 +1,42 @@
+"""add_updated_at_to_journal_entries
+
+Revision ID: 1330_journal_edit
+Revises: 679f6276cf18
+Create Date: 2026-03-07 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from datetime import datetime, timezone
+
+UTC = timezone.utc
+
+# revision identifiers, used by Alembic.
+revision: str = '1330_journal_edit'
+down_revision: Union[str, Sequence[str], None] = '679f6276cf18'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema: Add updated_at field to journal_entries table for tracking edits (Issue #1330)."""
+    
+    # Add updated_at column to journal_entries table
+    with op.batch_alter_table('journal_entries') as batch_op:
+        batch_op.add_column(
+            sa.Column('updated_at', sa.String(), 
+                     default=lambda: datetime.now(UTC).isoformat(), 
+                     nullable=True)
+        )
+        # Add index for efficient sorting by updated_at
+        batch_op.create_index('idx_journal_updated_at', ['updated_at'])
+
+
+def downgrade() -> None:
+    """Downgrade schema: Remove updated_at field from journal_entries table."""
+    
+    with op.batch_alter_table('journal_entries') as batch_op:
+        batch_op.drop_index('idx_journal_updated_at')
+        batch_op.drop_column('updated_at')


### PR DESCRIPTION
Allow users to edit past journal entries with automatic timestamp tracking and sentiment re-analysis.

### Changes:
- Added `updated_at` timestamp field to JournalEntry model for tracking modifications
- Updated `update_entry()` service method to set `updated_at` on each edit
- Added database migration to create `updated_at` column with index
- Updated JournalResponse schema to expose `updated_at` in API responses
- Frontend now displays most recent modification time for entries
- Edit functionality with form validation already exists in place

### Acceptance Criteria Met:

- ✅ Edit button present on journal entry detail page 
- ✅ API endpoint handles updates with sentiment re-analysis
-  ✅ Form validation for edited content
- ✅ Changes save successfully with timestamp tracking
-  ✅ Timeline displays accurate modification dates

closes: #1330
@nupurmadaan04  plz review it


Closes #1330
Fixes #1330