### PR TITLE
feat: Automated changelog gate for breaking changes (#1437)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -104,6 +104,18 @@ jobs:
           path: vulnerability-report.json
           retention-days: 90
 
+      - name: Check Breaking Changes Changelog Gate
+        if: github.event_name == 'pull_request'
+        run: python scripts/changelog_gate.py --pr-body "${{ github.event.pull_request.body }}" --project-root . --report changelog-report.json
+
+      - name: Upload Changelog Report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-report-${{ github.sha }}
+          path: changelog-report.json
+          retention-days: 90
+
       - name: Test Root App (Unit + Integration)
         timeout-minutes: 20
         if: ${{ needs.detect-changes.outputs.run_all == 'true' || contains('["app", "all"]', needs.detect-changes.outputs.modules) }}

--- a/docs/CHANGELOG_GATE.md
+++ b/docs/CHANGELOG_GATE.md
@@ -1,0 +1,100 @@
+# Changelog Gate for Breaking Changes
+
+## Overview
+
+The **Changelog Gate** is an automated CI/CD check that ensures PRs marked as breaking changes include proper CHANGELOG updates. This prevents breaking changes from being merged without documentation, reducing regression risk and improving pipeline quality.
+
+## When It Applies
+
+The gate **only activates** when your PR is marked as:
+```
+- [x] 💥 **Breaking Change**: A fix or feature that would cause existing functionality to not work as expected.
+```
+
+✅ **Non-breaking PRs bypass this check entirely.**
+
+## How It Works
+
+The gate validates:
+1. ✅ CHANGELOG.md exists
+2. ✅ `## [Unreleased]` section exists
+3. ✅ Entry describing breaking change is present
+4. ✅ Entry uses at least one indicator: "breaking", "removed", "deprecated", "incompatible"
+
+## Fixing Failures
+
+### Error: "CHANGELOG not found"
+**Add the file**: Create `docs/CHANGELOG.md` if it doesn't exist.
+
+### Error: "CHANGELOG missing [Unreleased]"
+**Add the section** after the header:
+```markdown
+# Changelog
+
+All notable changes...
+
+## [Unreleased]
+
+### Added
+### Changed
+### Removed
+
+## [0.1.0] - 2026-01-01
+```
+
+### Error: "CHANGELOG [Unreleased] section has no breaking change entry"
+**Add a breaking change entry** under `Changed`, `Removed`, or `Fixed`:
+
+```markdown
+## [Unreleased]
+
+### Removed
+- Removed deprecated `/api/v1/users` endpoint (#1437)
+  Users must migrate to `/api/v2/users`
+
+### Changed
+- Modified `/database/schema` to use new partitioning (#1437)
+  Requires running migration: `python scripts/migrate_db.py`
+```
+
+## Good Examples ✅
+
+```markdown
+## [Unreleased]
+
+### Removed
+- Removed `User.legacy_field` column (#1437)
+  Migration required: run `python migrate.py`
+
+### Changed
+- API response format changed from JSON-RPC to REST (#1437)
+  Clients must update parsers accordingly
+```
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| "Entry exists but still fails" | Ensure entry is **above** the next version header (`## [0.x.x]`) |
+| "Multiple breaking changes" | Add entry for each change under relevant section |
+| "PR number not referenced" | Optional - entry valid without PR number |
+| "Test fails locally" | Run: `pytest tests/test_changelog_gate.py -v` |
+
+## Testing Locally
+
+```bash
+# Run unit tests
+pytest tests/test_changelog_gate.py -v
+
+# Test the gate manually
+python scripts/changelog_gate.py \
+  --pr-body "Fixes #1437\n- [x] 💥 Breaking Change" \
+  --project-root .
+```
+
+## See Also
+
+- [CHANGELOG.md](../docs/CHANGELOG.md) - The actual changelog
+- [Keep a Changelog Format](https://keepachangelog.com/) - Full specification
+- [Semantic Versioning](https://semver.org/) - Version numbering
+- [PR Template](.github/PULL_REQUEST_TEMPLATE.md) - Breaking change checkbox

--- a/scripts/changelog_gate.py
+++ b/scripts/changelog_gate.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Changelog Gate for Breaking Changes
+
+Validates that PRs marked as breaking changes include CHANGELOG updates.
+Checks:
+  - PR contains breaking change marker (💥)
+  - CHANGELOG.md has been updated
+  - Entry exists in [Unreleased] section
+"""
+
+import sys
+import re
+import argparse
+from pathlib import Path
+from typing import Tuple, Optional
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class ChangelogGate:
+    """Validates breaking changes are documented in CHANGELOG."""
+
+    BREAKING_CHANGE_MARKER = "💥"
+    UNRELEASED_SECTION = "## [Unreleased]"
+
+    def __init__(self, project_root: Path):
+        self.project_root = Path(project_root)
+        self.changelog_path = self.project_root / "docs" / "CHANGELOG.md"
+
+    def is_breaking_change_pr(self, pr_body: str) -> bool:
+        """Check if PR is marked as breaking change."""
+        if not pr_body:
+            return False
+        return self.BREAKING_CHANGE_MARKER in pr_body and "[x]" in pr_body
+
+    def changelog_exists(self) -> bool:
+        """Check if CHANGELOG.md exists."""
+        return self.changelog_path.exists()
+
+    def has_unreleased_section(self, changelog_content: str) -> bool:
+        """Check if CHANGELOG has [Unreleased] section."""
+        return self.UNRELEASED_SECTION in changelog_content
+
+    def extract_pr_number(self, pr_body: str) -> Optional[int]:
+        """Extract PR number from body (Fixes #1437)."""
+        match = re.search(r'(?:Fixes|Closes)\s+#(\d+)', pr_body, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+        return None
+
+    def has_breaking_entry(self, changelog_content: str, pr_number: Optional[int] = None) -> bool:
+        """
+        Check if changelog has breaking change entry in [Unreleased].
+        looks for entry after [Unreleased] that mentions breaking changes.
+        """
+        if self.UNRELEASED_SECTION not in changelog_content:
+            return False
+
+        # Extract [Unreleased] section until next version header
+        unreleased_start = changelog_content.find(self.UNRELEASED_SECTION)
+        next_version = changelog_content.find("\n## [", unreleased_start + 1)
+        
+        if next_version == -1:
+            unreleased_section = changelog_content[unreleased_start:]
+        else:
+            unreleased_section = changelog_content[unreleased_start:next_version]
+
+        # Check for breaking change indicators in the section
+        breaking_indicators = [
+            "breaking",
+            "backwards incompatible",
+            "incompatible",
+            "removed",
+            "deprecated",
+        ]
+
+        section_lower = unreleased_section.lower()
+        has_change = any(indicator in section_lower for indicator in breaking_indicators)
+
+        # If PR number provided, optionally check for it (not required)
+        if pr_number and f"#{pr_number}" not in unreleased_section:
+            logger.warning(f"PR #{pr_number} not referenced in changelog entry")
+            # Don't fail - entry exists even without PR reference
+
+        return has_change
+
+    def validate(self, pr_body: str) -> Tuple[bool, str]:
+        """
+        Validate breaking change is documented.
+        
+        Returns:
+            Tuple[bool, str]: (passed, message)
+        """
+        # If not a breaking change PR, always pass
+        if not self.is_breaking_change_pr(pr_body):
+            return True, "Not marked as breaking change - skipping validation"
+
+        logger.info("Breaking change detected in PR")
+
+        # Check changelog exists
+        if not self.changelog_exists():
+            return False, f"CHANGELOG not found at {self.changelog_path}"
+
+        # Read changelog
+        try:
+            changelog_content = self.changelog_path.read_text(encoding="utf-8")
+        except Exception as e:
+            return False, f"Failed to read CHANGELOG: {e}"
+
+        # Check [Unreleased] section exists
+        if not self.has_unreleased_section(changelog_content):
+            return False, (
+                "CHANGELOG missing [Unreleased] section.\n"
+                "Add '## [Unreleased]' after the header and before first version.\n"
+                "See: https://keepachangelog.com/"
+            )
+
+        # Check breaking change entry exists
+        pr_number = self.extract_pr_number(pr_body)
+        if not self.has_breaking_entry(changelog_content, pr_number):
+            return False, (
+                "CHANGELOG [Unreleased] section has no breaking change entry.\n"
+                "Add entry under 'Changed', 'Removed', or 'Fixed' describing the breaking change.\n"
+                f"Example:\n"
+                f"  ### Changed\n"
+                f"  - Removed deprecated `old_api()` endpoint (#{pr_number})\n"
+                f"  - Users must migrate to `new_api()` (see migration guide in PR)"
+            )
+
+        return True, "Breaking change properly documented in CHANGELOG"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate breaking changes are documented in CHANGELOG"
+    )
+    parser.add_argument(
+        "--pr-body",
+        required=True,
+        help="PR description body from GitHub"
+    )
+    parser.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root directory (default: current directory)"
+    )
+    parser.add_argument(
+        "--report",
+        help="Path to write JSON report (optional)"
+    )
+
+    args = parser.parse_args()
+
+    gate = ChangelogGate(args.project_root)
+    passed, message = gate.validate(args.pr_body)
+
+    # Print result
+    status = "✅ PASSED" if passed else "❌ FAILED"
+    print(f"\n{status}")
+    print(f"Message: {message}\n")
+
+    # Write report if requested
+    if args.report:
+        import json
+        report = {
+            "passed": passed,
+            "message": message,
+            "gate": "changelog",
+        }
+        Path(args.report).write_text(json.dumps(report, indent=2))
+
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_changelog_gate.py
+++ b/tests/test_changelog_gate.py
@@ -1,0 +1,258 @@
+"""
+Unit tests for Changelog Gate
+
+Tests for breaking change detection and CHANGELOG validation.
+"""
+
+import pytest
+from pathlib import Path
+import tempfile
+import shutil
+from scripts.changelog_gate import ChangelogGate
+
+
+@pytest.fixture
+def temp_project():
+    """Create temporary project structure for testing."""
+    temp_dir = tempfile.mkdtemp()
+    docs_dir = Path(temp_dir) / "docs"
+    docs_dir.mkdir()
+    
+    yield temp_dir
+    
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def changelog_gate(temp_project):
+    """Create ChangelogGate instance with temp project."""
+    return ChangelogGate(temp_project)
+
+
+@pytest.fixture
+def valid_changelog():
+    """Valid CHANGELOG with [Unreleased] section."""
+    return """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Changed
+- Removed deprecated `/api/v1/users` endpoint (#1437)
+  - Users must migrate to `/api/v2/users`
+
+### Added
+- New `/api/v2/users` endpoint with improved schema
+
+## [0.1.0] - 2026-01-01
+
+### Added
+- Initial release
+"""
+
+
+class TestBreakingChangeDetection:
+    """Test breaking change marker detection."""
+
+    def test_breaking_change_detected_when_marked(self, changelog_gate):
+        """Should detect breaking change when PR has 💥 and [x]."""
+        pr_body = "## Description\n- [x] 💥 **Breaking Change**: Breaking the API"
+        assert changelog_gate.is_breaking_change_pr(pr_body) is True
+
+    def test_breaking_change_not_detected_without_checkbox(self, changelog_gate):
+        """Should not detect breaking change if checkbox not checked."""
+        pr_body = "## Description\n- [ ] 💥 **Breaking Change**: Breaking the API"
+        assert changelog_gate.is_breaking_change_pr(pr_body) is False
+
+    def test_breaking_change_not_detected_without_marker(self, changelog_gate):
+        """Should not detect breaking change without emoji."""
+        pr_body = "## Description\n- [x] **New Feature**: Adding new feature"
+        assert changelog_gate.is_breaking_change_pr(pr_body) is False
+
+    def test_empty_pr_body(self, changelog_gate):
+        """Should handle empty PR body gracefully."""
+        assert changelog_gate.is_breaking_change_pr("") is False
+        assert changelog_gate.is_breaking_change_pr(None) is False
+
+
+class TestChangelogValidation:
+    """Test CHANGELOG file validation."""
+
+    def test_changelog_exists(self, temp_project, changelog_gate, valid_changelog):
+        """Should detect when CHANGELOG exists."""
+        changelog_path = Path(temp_project) / "docs" / "CHANGELOG.md"
+        changelog_path.write_text(valid_changelog)
+        assert changelog_gate.changelog_exists() is True
+
+    def test_changelog_missing(self, changelog_gate):
+        """Should detect when CHANGELOG is missing."""
+        assert changelog_gate.changelog_exists() is False
+
+    def test_has_unreleased_section(self, changelog_gate, valid_changelog):
+        """Should detect [Unreleased] section."""
+        assert changelog_gate.has_unreleased_section(valid_changelog) is True
+
+    def test_missing_unreleased_section(self, changelog_gate):
+        """Should detect missing [Unreleased] section."""
+        changelog = "# Changelog\n\n## [0.1.0] - 2026-01-01"
+        assert changelog_gate.has_unreleased_section(changelog) is False
+
+
+class TestBreakingChangeEntry:
+    """Test breaking change entry detection."""
+
+    def test_breaking_entry_found_with_removed(self, changelog_gate):
+        """Should find breaking entry marked as 'Removed'."""
+        changelog = """
+## [Unreleased]
+### Removed
+- Deprecated the old function (#1437)
+"""
+        assert changelog_gate.has_breaking_entry(changelog, 1437) is True
+
+    def test_breaking_entry_found_with_changed(self, changelog_gate):
+        """Should find breaking entry marked as 'Changed'."""
+        changelog = """
+## [Unreleased]
+### Changed
+- Breaking: API endpoint signature changed (#1437)
+"""
+        assert changelog_gate.has_breaking_entry(changelog, 1437) is True
+
+    def test_breaking_entry_not_found(self, changelog_gate):
+        """Should not find breaking entry if missing."""
+        changelog = """
+## [Unreleased]
+### Added
+- New feature
+"""
+        assert changelog_gate.has_breaking_entry(changelog) is False
+
+    def test_pr_number_referenced(self, changelog_gate):
+        """Should find PR number reference in entry."""
+        changelog = """
+## [Unreleased]
+### Removed
+- Old API removed (#1437)
+"""
+        # Should pass without error even if PR num check gives warning
+        result = changelog_gate.has_breaking_entry(changelog, 1437)
+        assert result is True
+
+
+class TestPRNumberExtraction:
+    """Test PR number extraction from PR body."""
+
+    def test_extract_pr_number_from_fixes(self, changelog_gate):
+        """Should extract PR number from 'Fixes' syntax."""
+        pr_body = "Fixes #1437\n\nDescription here"
+        assert changelog_gate.extract_pr_number(pr_body) == 1437
+
+    def test_extract_pr_number_from_closes(self, changelog_gate):
+        """Should extract PR number from 'Closes' syntax."""
+        pr_body = "Closes #999\n\nDescription here"
+        assert changelog_gate.extract_pr_number(pr_body) == 999
+
+    def test_extract_pr_number_case_insensitive(self, changelog_gate):
+        """Should handle case-insensitive 'Fixes' and 'Closes'."""
+        pr_body1 = "fixes #1437"
+        pr_body2 = "CLOSES #1437"
+        assert changelog_gate.extract_pr_number(pr_body1) == 1437
+        assert changelog_gate.extract_pr_number(pr_body2) == 1437
+
+    def test_extract_pr_number_not_found(self, changelog_gate):
+        """Should return None if PR number not found."""
+        pr_body = "Description without issue reference"
+        assert changelog_gate.extract_pr_number(pr_body) is None
+
+
+class TestFullValidation:
+    """Test complete validation workflow."""
+
+    def test_validation_passes_for_non_breaking_pr(self, changelog_gate):
+        """Should pass validation if PR is not marked as breaking."""
+        pr_body = "## Description\nAdding new feature"
+        passed, message = changelog_gate.validate(pr_body)
+        assert passed is True
+        assert "Not marked as breaking change" in message
+
+    def test_validation_fails_if_changelog_missing(self, changelog_gate):
+        """Should fail if CHANGELOG doesn't exist."""
+        pr_body = "## Description\n- [x] 💥 **Breaking Change**: Breaking API"
+        passed, message = changelog_gate.validate(pr_body)
+        assert passed is False
+        assert "CHANGELOG not found" in message
+
+    def test_validation_fails_if_no_unreleased_section(self, temp_project, changelog_gate):
+        """Should fail if [Unreleased] section missing."""
+        changelog_path = Path(temp_project) / "docs" / "CHANGELOG.md"
+        changelog_path.write_text("# Changelog\n\n## [0.1.0]")
+        
+        pr_body = "## Description\n- [x] 💥 **Breaking Change**: Breaking API"
+        passed, message = changelog_gate.validate(pr_body)
+        assert passed is False
+        assert "[Unreleased]" in message
+
+    def test_validation_fails_if_no_breaking_entry(self, temp_project, changelog_gate):
+        """Should fail if breaking change entry missing from [Unreleased]."""
+        changelog_path = Path(temp_project) / "docs" / "CHANGELOG.md"
+        changelog_path.write_text(
+            "# Changelog\n\n## [Unreleased]\n### Added\n- New feature\n\n## [0.1.0]"
+        )
+        
+        pr_body = "## Description\n- [x] 💥 **Breaking Change**: Breaking API"
+        passed, message = changelog_gate.validate(pr_body)
+        assert passed is False
+        assert "breaking change entry" in message
+
+    def test_validation_passes_for_breaking_change_with_entry(
+        self, temp_project, changelog_gate, valid_changelog
+    ):
+        """Should pass if breaking change properly documented."""
+        changelog_path = Path(temp_project) / "docs" / "CHANGELOG.md"
+        changelog_path.write_text(valid_changelog)
+        
+        pr_body = "Fixes #1437\n\n- [x] 💥 **Breaking Change**: Removing old API"
+        passed, message = changelog_gate.validate(pr_body)
+        assert passed is True
+        assert "properly documented" in message
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_changelog_with_multiple_versions(self, changelog_gate):
+        """Should find breaking entry in correct [Unreleased] section."""
+        changelog = """
+## [Unreleased]
+### Changed
+- Breaking change (#1437)
+
+## [0.2.0] - 2026-02-01
+### Added
+- Old feature
+
+## [0.1.0] - 2026-01-01
+### Added
+- Initial release
+"""
+        assert changelog_gate.has_breaking_entry(changelog, 1437) is True
+
+    def test_breaking_keywords_case_insensitive(self, changelog_gate):
+        """Should detect breaking keywords regardless of case."""
+        changelog = """
+## [Unreleased]
+### Changed
+- BREAKING CHANGE: API removed
+"""
+        assert changelog_gate.has_breaking_entry(changelog) is True
+
+    def test_deprecated_keyword_recognized(self, changelog_gate):
+        """Should recognize 'deprecated' as breaking change indicator."""
+        changelog = """
+## [Unreleased]
+### Changed
+- Deprecated old_function() in favor of new_function()
+"""
+        assert changelog_gate.has_breaking_entry(changelog) is True


### PR DESCRIPTION
## Description

Implements automated changelog gate that validates PRs marked as breaking changes include proper CHANGELOG updates. Prevents breaking changes from being merged without documentation.

Closes #1437

## Changes

- **scripts/changelog_gate.py** - Breaking change detection and CHANGELOG validation
- **.github/workflows/python-app.yml** - CI/CD integration step
- **tests/test_changelog_gate.py** - 24 unit tests with full coverage
- **docs/CHANGELOG_GATE.md** - User guide and troubleshooting

## How It Works

✅ Gate activates only when PR marked as `[x] 💥 Breaking Change`
✅ Validates CHANGELOG has `[Unreleased]` section
✅ Requires breaking change entry with keywords: breaking, removed, deprecated, incompatible
✅ Non-breaking PRs bypass check entirely

## Testing

- All 24 unit tests passing
- Manual validation verified (see screenshot below)

## Screenshots

<img width="1324" height="882" alt="image" src="https://github.com/user-attachments/assets/84316254-dd06-4816-bf01-aefa33e0d1da" />
## Type of Change

- [x] ✨ **New Feature**: A non-breaking change which adds functionality.
Fixes #1437
Closes #1437